### PR TITLE
feat: add kit-haptics, add validation to other kit action packages, better validation errors

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -56,7 +56,8 @@
     "react-native-svg": "15.2.0",
     "react-native-web": "~0.19.6",
     "tamagui": "^1.100.3",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "expo-haptics": "~13.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@rise-tools/http-client": "0.2.0",
     "@rise-tools/ws-client": "0.2.0",
     "@rise-tools/tamagui": "0.2.0",
+    "@rise-tools/kit-haptics": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0",
     "@rise-tools/kit-tamagui-toast": "0.2.0",
     "@shopify/react-native-skia": "1.2.3",

--- a/apps/mobile/src/screens/connection.tsx
+++ b/apps/mobile/src/screens/connection.tsx
@@ -1,5 +1,6 @@
 import { RiseComponents } from '@rise-tools/kit'
 import { useExpoRouterActions } from '@rise-tools/kit-expo-router'
+import { useHapticsActions } from '@rise-tools/kit-haptics'
 import { useToastActions } from '@rise-tools/kit-tamagui-toast'
 import { Rise } from '@rise-tools/react'
 import { TamaguiComponents } from '@rise-tools/tamagui'
@@ -27,6 +28,7 @@ export function ConnectionScreen({ connection, path }: { connection: Connection;
   const actions = {
     ...useExpoRouterActions({ basePath: `/connection/${connection.id}` }),
     ...useToastActions(),
+    ...useHapticsActions(),
   }
 
   const modelSource = useModelSource(connection.id, connection.host)

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -31,7 +31,10 @@
       "path": "../../packages/tamagui"
     },
     {
+      "path": "../../packages/kit-haptics"
+    },
+    {
       "path": "../../packages/kit-tamagui-toast"
-    }
+    },
   ]
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -35,6 +35,6 @@
     },
     {
       "path": "../../packages/kit-tamagui-toast"
-    },
+    }
   ]
 }

--- a/docs/docs/kit/haptics.md
+++ b/docs/docs/kit/haptics.md
@@ -10,11 +10,11 @@ npm install @rise-tools/kit-haptics expo-haptics
 
 Shorthand for `haptics('impact')`
 
-- `haptics('impact', type?: 'heavy' | 'light' | 'medium' | 'rigid' | 'soft' = 'medium')`
+- `haptics('impact', type: 'heavy' | 'light' | 'medium' | 'rigid' | 'soft' = 'medium')`
 
 Use this action to provide haptic feedback for physical impact. Type is optional and defaults to `medium`.
 
-- `haptics('notification', type?: 'success' | 'failure' | 'error' = 'success')`
+- `haptics('notification', type: 'success' | 'failure' | 'error' = 'success')`
 
 Use this action to provide haptic feedback for success, failure, and warning. Type is optional and defaults to `success`.
 

--- a/docs/docs/kit/haptics.md
+++ b/docs/docs/kit/haptics.md
@@ -7,6 +7,21 @@ npm install @rise-tools/kit-haptics expo-haptics
 ## Actions
 
 - `haptics()`
-- `haptics('impact', type)`
-- `haptics('notification', type)`
+
+Shorthand for `haptics('impact')`
+
+- `haptics('impact', type?: 'heavy' | 'light' | 'medium' | 'rigid' | 'soft' = 'medium')`
+
+Use this action to provide haptic feedback for physical impact. Type is optional and defaults to `medium`.
+
+- `haptics('notification', type?: 'success' | 'failure' | 'error' = 'success')`
+
+Use this action to provide haptic feedback for success, failure, and warning. Type is optional and defaults to `success`.
+
 - `haptics('selection')`
+
+Use this action to let user know when a selection change has been registered.
+
+---
+
+Check [expo-haptics](Check https://docs.expo.dev/versions/latest/sdk/haptics/) documentation for more.

--- a/docs/docs/kit/haptics.md
+++ b/docs/docs/kit/haptics.md
@@ -3,3 +3,10 @@
 ```sh
 npm install @rise-tools/kit-haptics expo-haptics
 ```
+
+## Actions
+
+- `haptics`
+- `haptics('impact', type)`
+- `haptics('notification', type)`
+- `haptics('selection', type)`

--- a/docs/docs/kit/haptics.md
+++ b/docs/docs/kit/haptics.md
@@ -6,7 +6,7 @@ npm install @rise-tools/kit-haptics expo-haptics
 
 ## Actions
 
-- `haptics`
+- `haptics()`
 - `haptics('impact', type)`
 - `haptics('notification', type)`
-- `haptics('selection', type)`
+- `haptics('selection')`

--- a/example/demo/package.json
+++ b/example/demo/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@rise-tools/tamagui": "0.2.0",
     "@rise-tools/kit": "0.2.0",
+    "@rise-tools/kit-haptics": "0.2.0",
     "@rise-tools/server": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0"
   },

--- a/example/demo/package.json
+++ b/example/demo/package.json
@@ -21,6 +21,7 @@
     "@rise-tools/tamagui": "0.2.0",
     "@rise-tools/kit": "0.2.0",
     "@rise-tools/kit-haptics": "0.2.0",
+    "@rise-tools/kit-tamagui-toast": "0.2.0",
     "@rise-tools/server": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0"
   },

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -7,7 +7,8 @@ import {
 } from '@rise-tools/kit/server'
 import { navigate } from '@rise-tools/kit-expo-router/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
-import { action, event, eventPayload, response, setStateAction, state } from '@rise-tools/react'
+import { toast } from '@rise-tools/kit-tamagui-toast/server'
+import { event, eventPayload, response, setStateAction, state } from '@rise-tools/react'
 import { Button, Form, H4, Input, Paragraph, Text, YStack } from '@rise-tools/tamagui/server'
 
 // eslint-disable-next-line
@@ -180,9 +181,7 @@ function ListExample() {
 function ShowToastExample() {
   return (
     <YStack>
-      <Button
-        onPress={action('toast', { title: 'Hello World!', message: 'This is toast action!' })}
-      >
+      <Button onPress={toast('Hello World!', 'This is toast action!')}>
         <Text>Show toast</Text>
       </Button>
     </YStack>

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -195,6 +195,12 @@ function HapticsExample() {
       <Button onPress={haptics()}>
         <Text>Impact</Text>
       </Button>
+      <Button onPress={haptics('notification')}>
+        <Text>Notification</Text>
+      </Button>
+      <Button onPress={haptics('selection')}>
+        <Text>Selection</Text>
+      </Button>
     </YStack>
   )
 }

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -9,7 +9,16 @@ import { navigate } from '@rise-tools/kit-expo-router/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import { event, eventPayload, response, setStateAction, state } from '@rise-tools/react'
-import { Button, Form, H4, Input, Paragraph, Text, YStack } from '@rise-tools/tamagui/server'
+import {
+  Button,
+  Form,
+  H4,
+  Input,
+  Paragraph,
+  ScrollView,
+  Text,
+  YStack,
+} from '@rise-tools/tamagui/server'
 
 // eslint-disable-next-line
 export const models = {
@@ -190,16 +199,55 @@ function ShowToastExample() {
 
 function HapticsExample() {
   return (
-    <YStack>
-      <Button onPress={haptics()}>
-        <Text>Impact</Text>
-      </Button>
-      <Button onPress={haptics('notification')}>
-        <Text>Notification</Text>
-      </Button>
-      <Button onPress={haptics('selection')}>
-        <Text>Selection</Text>
-      </Button>
-    </YStack>
+    <ScrollView padding="$4" contentContainerStyle={{ gap: '$8' }}>
+      <YStack>
+        <H4>Impact</H4>
+        <YStack gap="$2">
+          <Button onPress={haptics()}>
+            <Text>Default</Text>
+          </Button>
+          <Button onPress={haptics('impact', 'light')}>
+            <Text>Light</Text>
+          </Button>
+          <Button onPress={haptics('impact', 'medium')}>
+            <Text>Medium</Text>
+          </Button>
+          <Button onPress={haptics('impact', 'heavy')}>
+            <Text>Heavy</Text>
+          </Button>
+          <Button onPress={haptics('impact', 'rigid')}>
+            <Text>Rigid</Text>
+          </Button>
+          <Button onPress={haptics('impact', 'soft')}>
+            <Text>Soft</Text>
+          </Button>
+        </YStack>
+      </YStack>
+      <YStack>
+        <H4>Notification</H4>
+        <YStack gap="$2">
+          <Button onPress={haptics('notification')}>
+            <Text>Default</Text>
+          </Button>
+          <Button onPress={haptics('notification', 'success')}>
+            <Text>Success</Text>
+          </Button>
+          <Button onPress={haptics('notification', 'error')}>
+            <Text>Error</Text>
+          </Button>
+          <Button onPress={haptics('notification', 'warning')}>
+            <Text>Warning</Text>
+          </Button>
+        </YStack>
+      </YStack>
+      <YStack>
+        <H4>Notification</H4>
+        <YStack gap="$2">
+          <Button onPress={haptics('selection')}>
+            <Text>Default</Text>
+          </Button>
+        </YStack>
+      </YStack>
+    </ScrollView>
   )
 }

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -6,6 +6,7 @@ import {
   SwitchField,
 } from '@rise-tools/kit/server'
 import { navigate } from '@rise-tools/kit-expo-router/server'
+import { haptics } from '@rise-tools/kit-haptics/server'
 import { action, event, eventPayload, response, setStateAction, state } from '@rise-tools/react'
 import { Button, Form, H4, Input, Paragraph, Text, YStack } from '@rise-tools/tamagui/server'
 
@@ -18,6 +19,7 @@ export const models = {
   select: SelectExample,
   list: ListExample,
   toast: ShowToastExample,
+  haptics: HapticsExample,
 }
 
 function UI() {
@@ -29,6 +31,7 @@ function UI() {
       <Button onPress={navigate('select')}>Select</Button>
       <Button onPress={navigate('list')}>List</Button>
       <Button onPress={navigate('toast')}>Toast</Button>
+      <Button onPress={navigate('haptics')}>Haptics</Button>
     </YStack>
   )
 }
@@ -181,6 +184,16 @@ function ShowToastExample() {
         onPress={action('toast', { title: 'Hello World!', message: 'This is toast action!' })}
       >
         <Text>Show toast</Text>
+      </Button>
+    </YStack>
+  )
+}
+
+function HapticsExample() {
+  return (
+    <YStack>
+      <Button onPress={haptics()}>
+        <Text>Impact</Text>
       </Button>
     </YStack>
   )

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -241,7 +241,7 @@ function HapticsExample() {
         </YStack>
       </YStack>
       <YStack>
-        <H4>Notification</H4>
+        <H4>Selection</H4>
         <YStack gap="$2">
           <Button onPress={haptics('selection')}>
             <Text>Default</Text>

--- a/example/demo/tsconfig.json
+++ b/example/demo/tsconfig.json
@@ -11,6 +11,8 @@
   }, {
     "path": "../../packages/kit-expo-router"
   }, {
+    "path": "../../packages/kit-haptics"
+  }, {
     "path": "../../packages/server"
   }, {
     "path": "../../packages/kit"

--- a/example/demo/tsconfig.json
+++ b/example/demo/tsconfig.json
@@ -13,6 +13,8 @@
   }, {
     "path": "../../packages/kit-haptics"
   }, {
+    "path": "../../packages/kit-tamagui-toast"
+  }, {
     "path": "../../packages/server"
   }, {
     "path": "../../packages/kit"

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,7 @@
       "dependencies": {
         "@rise-tools/kit": "0.2.0",
         "@rise-tools/kit-expo-router": "0.2.0",
+        "@rise-tools/kit-haptics": "0.2.0",
         "@rise-tools/server": "0.2.0",
         "@rise-tools/tamagui": "0.2.0"
       },
@@ -33876,7 +33877,8 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@rise-tools/react": "0.2.0"
+        "@rise-tools/react": "0.2.0",
+        "zod": "^3.22.4"
       },
       "peerDependencies": {
         "expo-router": "~3.5.16"
@@ -33888,7 +33890,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@rise-tools/react": "0.2.0",
-        "zod": "^3.23.8"
+        "zod": "^3.22.4"
       },
       "peerDependencies": {
         "expo-haptics": "~13.0.1"
@@ -33899,7 +33901,8 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@rise-tools/react": "0.2.0"
+        "@rise-tools/react": "0.2.0",
+        "zod": "^3.22.4"
       },
       "peerDependencies": {
         "@tamagui/toast": "^1.100.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "expo-crypto": "~13.0.2",
         "expo-dev-client": "~4.0.18",
         "expo-font": "~12.0.7",
+        "expo-haptics": "~13.0.1",
         "expo-linear-gradient": "~13.0.2",
         "expo-linking": "~6.3.1",
         "expo-router": "~3.5.16",
@@ -7251,6 +7252,10 @@
     },
     "node_modules/@rise-tools/kit-expo-router": {
       "resolved": "packages/kit-expo-router",
+      "link": true
+    },
+    "node_modules/@rise-tools/kit-haptics": {
+      "resolved": "packages/kit-haptics",
       "link": true
     },
     "node_modules/@rise-tools/kit-tamagui-toast": {
@@ -15960,6 +15965,14 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-13.0.1.tgz",
+      "integrity": "sha512-qG0EOLDE4bROVT3DtUSyV9g3iB3YFu9j3711X7SNNEnBDXc+2/p3wGDPTnJvPW0ao6HG3/McAOrBQA5hVSdWng==",
       "peerDependencies": {
         "expo": "*"
       }
@@ -33778,8 +33791,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "license": "MIT",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -33864,11 +33878,20 @@
       "dependencies": {
         "@rise-tools/react": "0.2.0"
       },
-      "devDependencies": {
+      "peerDependencies": {
         "expo-router": "~3.5.16"
+      }
+    },
+    "packages/kit-haptics": {
+      "name": "@rise-tools/kit-haptics",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rise-tools/react": "0.2.0",
+        "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "expo-router": "^3"
+        "expo-haptics": "~13.0.1"
       }
     },
     "packages/kit-tamagui-toast": {
@@ -33879,8 +33902,8 @@
         "@rise-tools/react": "0.2.0"
       },
       "peerDependencies": {
-        "@tamagui/toast": "*",
-        "react-native-safe-area-context": "*"
+        "@tamagui/toast": "^1.100.3",
+        "react-native-safe-area-context": ">= 3.0.0"
       }
     },
     "packages/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@rise-tools/http-client": "0.2.0",
         "@rise-tools/kit": "0.2.0",
         "@rise-tools/kit-expo-router": "0.2.0",
+        "@rise-tools/kit-haptics": "0.2.0",
         "@rise-tools/kit-tamagui-toast": "0.2.0",
         "@rise-tools/react": "0.2.0",
         "@rise-tools/tamagui": "0.2.0",
@@ -164,6 +165,7 @@
         "@rise-tools/kit": "0.2.0",
         "@rise-tools/kit-expo-router": "0.2.0",
         "@rise-tools/kit-haptics": "0.2.0",
+        "@rise-tools/kit-tamagui-toast": "0.2.0",
         "@rise-tools/server": "0.2.0",
         "@rise-tools/tamagui": "0.2.0"
       },

--- a/packages/kit-expo-router/package.json
+++ b/packages/kit-expo-router/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "dependencies": {
     "@rise-tools/react": "0.2.0",
-    "zod": "^3.23.8"
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "expo-router": "~3.5.16"

--- a/packages/kit-expo-router/package.json
+++ b/packages/kit-expo-router/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "dependencies": {
-    "@rise-tools/react": "0.2.0"
+    "@rise-tools/react": "0.2.0",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
     "expo-router": "~3.5.16"

--- a/packages/kit-expo-router/src/index.ts
+++ b/packages/kit-expo-router/src/index.ts
@@ -1,26 +1,23 @@
-import type { ActionsDefinition } from '@rise-tools/react'
 import { useRouter } from 'expo-router'
 import z from 'zod'
 
-import type { goBack, navigate } from './server'
+import type { ExpoRouterActions } from './server'
 
 const NavigateActionPayload = z.object({
   path: z.string(),
 })
 
-type ExpoRouterActions = ActionsDefinition<ReturnType<typeof navigate> | ReturnType<typeof goBack>>
-
 export const useExpoRouterActions = (opts?: { basePath?: string }): ExpoRouterActions => {
   const router = useRouter()
 
   return {
-    navigate: {
+    '@rise-tools/kit-expo-router/navigate': {
       action: ({ path }) => {
         router.push([opts?.basePath || '', path].join('/'))
       },
       validate: (payload) => NavigateActionPayload.parse(payload),
     },
-    goBack: {
+    '@rise-tools/kit-expo-router/goBack': {
       action: () => {
         router.back()
       },

--- a/packages/kit-expo-router/src/index.ts
+++ b/packages/kit-expo-router/src/index.ts
@@ -1,12 +1,14 @@
-import type { ActionDefinition } from '@rise-tools/react'
+import type { ActionsDefinition } from '@rise-tools/react'
 import { useRouter } from 'expo-router'
+import z from 'zod'
 
 import type { goBack, navigate } from './server'
 
-type ExpoRouterActions = {
-  navigate: ActionDefinition<ReturnType<typeof navigate>>
-  goBack: ActionDefinition<ReturnType<typeof goBack>>
-}
+const NavigateActionPayload = z.object({
+  path: z.string(),
+})
+
+type ExpoRouterActions = ActionsDefinition<ReturnType<typeof navigate> | ReturnType<typeof goBack>>
 
 export const useExpoRouterActions = (opts?: { basePath?: string }): ExpoRouterActions => {
   const router = useRouter()
@@ -16,6 +18,7 @@ export const useExpoRouterActions = (opts?: { basePath?: string }): ExpoRouterAc
       action: ({ path }) => {
         router.push([opts?.basePath || '', path].join('/'))
       },
+      validate: (payload) => NavigateActionPayload.parse(payload),
     },
     goBack: {
       action: () => {

--- a/packages/kit-expo-router/src/server.ts
+++ b/packages/kit-expo-router/src/server.ts
@@ -1,9 +1,8 @@
 import { action, ActionsDefinition } from '@rise-tools/react'
 
-export type ExpoRouterActions = ActionsDefinition<{
-  '@rise-tools/kit-expo-router/navigate': ReturnType<typeof navigate>
-  '@rise-tools/kit-expo-router/goBack': ReturnType<typeof goBack>
-}>
+export type ExpoRouterActions = ActionsDefinition<
+  [ReturnType<typeof navigate>, ReturnType<typeof goBack>]
+>
 
 export const navigate = (path: string) => action('@rise-tools/kit-expo-router/navigate', { path })
 export const goBack = () => action('@rise-tools/kit-expo-router/goBack')

--- a/packages/kit-expo-router/src/server.ts
+++ b/packages/kit-expo-router/src/server.ts
@@ -1,4 +1,9 @@
-import { action } from '@rise-tools/react'
+import { action, ActionsDefinition } from '@rise-tools/react'
 
-export const navigate = (path: string) => action('navigate', { path })
-export const goBack = () => action('goBack')
+export type ExpoRouterActions = ActionsDefinition<{
+  '@rise-tools/kit-expo-router/navigate': ReturnType<typeof navigate>
+  '@rise-tools/kit-expo-router/goBack': ReturnType<typeof goBack>
+}>
+
+export const navigate = (path: string) => action('@rise-tools/kit-expo-router/navigmate', { path })
+export const goBack = () => action('@rise-tools/kit-expo-router/goBack')

--- a/packages/kit-expo-router/src/server.ts
+++ b/packages/kit-expo-router/src/server.ts
@@ -5,5 +5,5 @@ export type ExpoRouterActions = ActionsDefinition<{
   '@rise-tools/kit-expo-router/goBack': ReturnType<typeof goBack>
 }>
 
-export const navigate = (path: string) => action('@rise-tools/kit-expo-router/navigmate', { path })
+export const navigate = (path: string) => action('@rise-tools/kit-expo-router/navigate', { path })
 export const goBack = () => action('@rise-tools/kit-expo-router/goBack')

--- a/packages/kit-haptics/README.md
+++ b/packages/kit-haptics/README.md
@@ -1,0 +1,2 @@
+@rise-tools/kit-haptics
+=====

--- a/packages/kit-haptics/package.json
+++ b/packages/kit-haptics/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rise-tools/kit-haptics",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "description": "",
+  "exports": {
+    ".": "./lib/index.js",
+    "./server": "./lib/server.js"
+  },
+  "files": [
+    "src",
+    "lib",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__",
+    "!**/.*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rise-tools/rise-tools.git",
+    "directory": "packages/kit-expo-router"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Mike Grabowski <grabbou@gmail.com> (https://github.com/grabbou)",
+  "bugs": {
+    "url": "https://github.com/rise-tools/rise-tools/issues"
+  },
+  "homepage": "https://github.com/rise-tools/rise-tools#readme",
+  "dependencies": {
+    "@rise-tools/react": "0.2.0",
+    "zod": "^3.23.8"
+  },
+  "peerDependencies": {
+    "expo-haptics": "~13.0.1"
+  }
+}

--- a/packages/kit-haptics/package.json
+++ b/packages/kit-haptics/package.json
@@ -18,7 +18,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/rise-tools/rise-tools.git",
-    "directory": "packages/kit-expo-router"
+    "directory": "packages/kit-haptics"
   },
   "publishConfig": {
     "access": "public"
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "dependencies": {
     "@rise-tools/react": "0.2.0",
-    "zod": "^3.23.8"
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "expo-haptics": "~13.0.1"

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -1,0 +1,41 @@
+import type { ActionDefinition } from '@rise-tools/react'
+import * as Haptics from 'expo-haptics'
+import z from 'zod'
+
+import type { ImpactAction, NotificationAction } from './server'
+
+const ImpactActionPayload = z.object({
+  style: z.nativeEnum(Haptics.ImpactFeedbackStyle),
+})
+
+const NotificationActionPayload = z.object({
+  type: z.nativeEnum(Haptics.NotificationFeedbackType),
+})
+
+type HapticsActions = {
+  'haptics/impact': ActionDefinition<ImpactAction>
+  'haptics/notification': ActionDefinition<NotificationAction>
+  'haptics/selection': ActionDefinition<never>
+}
+
+export const useHapticsActions = (): HapticsActions => {
+  return {
+    'haptics/impact': {
+      action: ({ style }) => {
+        Haptics.impactAsync(style)
+      },
+      validate: (payload) => ImpactActionPayload.parse(payload),
+    },
+    'haptics/notification': {
+      action: ({ type }) => {
+        Haptics.notificationAsync(type)
+      },
+      validate: (payload) => NotificationActionPayload.parse(payload),
+    },
+    'haptics/selection': {
+      action: () => {
+        Haptics.selectionAsync()
+      },
+    },
+  }
+}

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -2,8 +2,6 @@ import type { ActionDefinition } from '@rise-tools/react'
 import * as Haptics from 'expo-haptics'
 import z from 'zod'
 
-import type { ImpactAction, NotificationAction } from './server'
-
 const ImpactActionPayload = z.object({
   style: z.nativeEnum(Haptics.ImpactFeedbackStyle),
 })
@@ -13,8 +11,8 @@ const NotificationActionPayload = z.object({
 })
 
 type HapticsActions = {
-  'haptics/impact': ActionDefinition<ImpactAction>
-  'haptics/notification': ActionDefinition<NotificationAction>
+  'haptics/impact': ActionDefinition<z.infer<typeof ImpactActionPayload>>
+  'haptics/notification': ActionDefinition<z.infer<typeof NotificationActionPayload>>
   'haptics/selection': ActionDefinition<never>
 }
 

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from '@rise-tools/react'
+import type { ActionsDefinition } from '@rise-tools/react'
 import * as Haptics from 'expo-haptics'
 import z from 'zod'
 
@@ -12,11 +12,7 @@ const NotificationActionPayload = z.object({
   type: z.nativeEnum(Haptics.NotificationFeedbackType),
 })
 
-type HapticsActions = {
-  'haptics/impact': ActionDefinition<ImpactAction>
-  'haptics/notification': ActionDefinition<NotificationAction>
-  'haptics/selection': ActionDefinition<SelectionAction>
-}
+type HapticsActions = ActionsDefinition<ImpactAction | NotificationAction | SelectionAction>
 
 export const useHapticsActions = (): HapticsActions => {
   return {

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -2,6 +2,8 @@ import type { ActionDefinition } from '@rise-tools/react'
 import * as Haptics from 'expo-haptics'
 import z from 'zod'
 
+import type { ImpactAction, NotificationAction, SelectionAction } from './server'
+
 const ImpactActionPayload = z.object({
   style: z.nativeEnum(Haptics.ImpactFeedbackStyle),
 })
@@ -11,9 +13,9 @@ const NotificationActionPayload = z.object({
 })
 
 type HapticsActions = {
-  'haptics/impact': ActionDefinition<z.infer<typeof ImpactActionPayload>>
-  'haptics/notification': ActionDefinition<z.infer<typeof NotificationActionPayload>>
-  'haptics/selection': ActionDefinition<never>
+  'haptics/impact': ActionDefinition<ImpactAction>
+  'haptics/notification': ActionDefinition<NotificationAction>
+  'haptics/selection': ActionDefinition<SelectionAction>
 }
 
 export const useHapticsActions = (): HapticsActions => {

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -1,8 +1,7 @@
-import type { ActionsDefinition } from '@rise-tools/react'
 import * as Haptics from 'expo-haptics'
 import z from 'zod'
 
-import type { ImpactAction, NotificationAction, SelectionAction } from './server'
+import type { HapticsActions } from './server'
 
 const ImpactActionPayload = z.object({
   style: z.nativeEnum(Haptics.ImpactFeedbackStyle).optional(),
@@ -12,23 +11,21 @@ const NotificationActionPayload = z.object({
   type: z.nativeEnum(Haptics.NotificationFeedbackType).optional(),
 })
 
-type HapticsActions = ActionsDefinition<ImpactAction | NotificationAction | SelectionAction>
-
 export const useHapticsActions = (): HapticsActions => {
   return {
-    'haptics/impact': {
+    '@rise-tools/kit-haptics/impact': {
       action: ({ style }) => {
         Haptics.impactAsync(style)
       },
       validate: (payload) => ImpactActionPayload.parse(payload),
     },
-    'haptics/notification': {
+    '@rise-tools/kit-haptics/notification': {
       action: ({ type }) => {
         Haptics.notificationAsync(type)
       },
       validate: (payload) => NotificationActionPayload.parse(payload),
     },
-    'haptics/selection': {
+    '@rise-tools/kit-haptics/selection': {
       action: () => {
         Haptics.selectionAsync()
       },

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -5,17 +5,16 @@ import z from 'zod'
 import type { ImpactAction, NotificationAction, SelectionAction } from './server'
 
 const ImpactActionPayload = z.object({
-  style: z.nativeEnum(Haptics.ImpactFeedbackStyle).or(z.undefined()),
+  style: z.nativeEnum(Haptics.ImpactFeedbackStyle).optional(),
 })
 
 const NotificationActionPayload = z.object({
-  type: z.nativeEnum(Haptics.NotificationFeedbackType).or(z.undefined()),
+  type: z.nativeEnum(Haptics.NotificationFeedbackType).optional(),
 })
 
 type HapticsActions = ActionsDefinition<ImpactAction | NotificationAction | SelectionAction>
 
 export const useHapticsActions = (): HapticsActions => {
-  // @ts-ignore https://github.com/colinhacks/zod/issues/635
   return {
     'haptics/impact': {
       action: ({ style }) => {

--- a/packages/kit-haptics/src/index.ts
+++ b/packages/kit-haptics/src/index.ts
@@ -5,16 +5,17 @@ import z from 'zod'
 import type { ImpactAction, NotificationAction, SelectionAction } from './server'
 
 const ImpactActionPayload = z.object({
-  style: z.nativeEnum(Haptics.ImpactFeedbackStyle),
+  style: z.nativeEnum(Haptics.ImpactFeedbackStyle).or(z.undefined()),
 })
 
 const NotificationActionPayload = z.object({
-  type: z.nativeEnum(Haptics.NotificationFeedbackType),
+  type: z.nativeEnum(Haptics.NotificationFeedbackType).or(z.undefined()),
 })
 
 type HapticsActions = ActionsDefinition<ImpactAction | NotificationAction | SelectionAction>
 
 export const useHapticsActions = (): HapticsActions => {
+  // @ts-ignore https://github.com/colinhacks/zod/issues/635
   return {
     'haptics/impact': {
       action: ({ style }) => {

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -1,11 +1,7 @@
 import { action, ActionModelState, ActionsDefinition } from '@rise-tools/react'
 import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
 
-export type HapticsActions = ActionsDefinition<{
-  '@rise-tools/kit-haptics/impact': ImpactAction
-  '@rise-tools/kit-haptics/notification': NotificationAction
-  '@rise-tools/kit-haptics/selection': SelectionAction
-}>
+export type HapticsActions = ActionsDefinition<[ImpactAction, NotificationAction, SelectionAction]>
 
 type SelectionAction = ActionModelState<'@rise-tools/kit-haptics/selection'>
 type ImpactAction = ActionModelState<

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -2,13 +2,10 @@ import { action, ActionModelState } from '@rise-tools/react'
 import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
 
 export type SelectionAction = ActionModelState<'haptics/selection'>
-export type ImpactAction = ActionModelState<
-  'haptics/impact',
-  { style: ImpactFeedbackStyle | undefined }
->
+export type ImpactAction = ActionModelState<'haptics/impact', { style?: ImpactFeedbackStyle }>
 export type NotificationAction = ActionModelState<
   'haptics/notification',
-  { type: NotificationFeedbackType | undefined }
+  { type?: NotificationFeedbackType }
 >
 
 export function haptics(): ImpactAction
@@ -25,9 +22,9 @@ export function haptics(
 ) {
   switch (type) {
     case 'impact':
-      return action('haptics/impact', { style })
+      return action('haptics/impact', style ? { style } : {})
     case 'notification':
-      return action('haptics/notification', { type: style })
+      return action('haptics/notification', style ? { type: style } : {})
     case 'selection':
       return action('haptics/selection')
     default:

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -2,10 +2,13 @@ import { action, ActionModelState } from '@rise-tools/react'
 import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
 
 export type SelectionAction = ActionModelState<'haptics/selection'>
-export type ImpactAction = ActionModelState<'haptics/impact', { style: ImpactFeedbackStyle }>
+export type ImpactAction = ActionModelState<
+  'haptics/impact',
+  { style: ImpactFeedbackStyle | undefined }
+>
 export type NotificationAction = ActionModelState<
   'haptics/notification',
-  { type: NotificationFeedbackType }
+  { type: NotificationFeedbackType | undefined }
 >
 
 export function haptics(): ImpactAction

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -1,0 +1,30 @@
+import { action, ActionModelState } from '@rise-tools/react'
+import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
+
+export type SelectionAction = ActionModelState<'haptics/selection'>
+export type ImpactAction = ActionModelState<'haptics/impact', { style: ImpactFeedbackStyle }>
+export type NotificationAction = ActionModelState<
+  'haptics/notification',
+  { type: NotificationFeedbackType }
+>
+
+export function haptics(): ImpactAction
+export function haptics(type: 'impact', style?: ImpactFeedbackStyle): ImpactAction
+export function haptics(type: 'notification', style?: NotificationFeedbackType): NotificationAction
+export function haptics(type: 'selection'): SelectionAction
+
+export function haptics(
+  type: 'impact' | 'notification' | 'selection' = 'impact',
+  style?: ImpactFeedbackStyle | NotificationFeedbackType
+) {
+  switch (type) {
+    case 'impact':
+      return action('haptics/impact', { style })
+    case 'notification':
+      return action('haptics/notification', { type: style })
+    case 'selection':
+      return action('haptics/selection')
+    default:
+      throw new Error(`Invalid haptics type: ${type}`)
+  }
+}

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -1,10 +1,19 @@
-import { action, ActionModelState } from '@rise-tools/react'
+import { action, ActionModelState, ActionsDefinition } from '@rise-tools/react'
 import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
 
-export type SelectionAction = ActionModelState<'haptics/selection'>
-export type ImpactAction = ActionModelState<'haptics/impact', { style?: ImpactFeedbackStyle }>
-export type NotificationAction = ActionModelState<
-  'haptics/notification',
+export type HapticsActions = ActionsDefinition<{
+  '@rise-tools/kit-haptics/impact': ImpactAction
+  '@rise-tools/kit-haptics/notification': NotificationAction
+  '@rise-tools/kit-haptics/selection': SelectionAction
+}>
+
+type SelectionAction = ActionModelState<'@rise-tools/kit-haptics/selection'>
+type ImpactAction = ActionModelState<
+  '@rise-tools/kit-haptics/impact',
+  { style?: ImpactFeedbackStyle }
+>
+type NotificationAction = ActionModelState<
+  '@rise-tools/kit-haptics/notification',
   { type?: NotificationFeedbackType }
 >
 
@@ -22,11 +31,11 @@ export function haptics(
 ) {
   switch (type) {
     case 'impact':
-      return action('haptics/impact', style ? { style } : {})
+      return action('@rise-tools/kit-haptics/impact', style ? { style } : {})
     case 'notification':
-      return action('haptics/notification', style ? { type: style } : {})
+      return action('@rise-tools/kit-haptics/notification', style ? { type: style } : {})
     case 'selection':
-      return action('haptics/selection')
+      return action('@rise-tools/kit-haptics/selection')
     default:
       throw new Error(`Invalid haptics type: ${type}`)
   }

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -1,21 +1,24 @@
 import { action, ActionModelState } from '@rise-tools/react'
 import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
 
-export type SelectionAction = ActionModelState<'haptics/selection'>
-export type ImpactAction = ActionModelState<'haptics/impact', { style: ImpactFeedbackStyle }>
-export type NotificationAction = ActionModelState<
+type SelectionAction = ActionModelState<'haptics/selection'>
+type ImpactAction = ActionModelState<'haptics/impact', { style: `${ImpactFeedbackStyle}` }>
+type NotificationAction = ActionModelState<
   'haptics/notification',
-  { type: NotificationFeedbackType }
+  { type: `${NotificationFeedbackType}` }
 >
 
 export function haptics(): ImpactAction
-export function haptics(type: 'impact', style?: ImpactFeedbackStyle): ImpactAction
-export function haptics(type: 'notification', style?: NotificationFeedbackType): NotificationAction
+export function haptics(type: 'impact', style?: `${ImpactFeedbackStyle}`): ImpactAction
+export function haptics(
+  type: 'notification',
+  style?: `${NotificationFeedbackType}`
+): NotificationAction
 export function haptics(type: 'selection'): SelectionAction
 
 export function haptics(
   type: 'impact' | 'notification' | 'selection' = 'impact',
-  style?: ImpactFeedbackStyle | NotificationFeedbackType
+  style?: `${ImpactFeedbackStyle}` | `${NotificationFeedbackType}`
 ) {
   switch (type) {
     case 'impact':

--- a/packages/kit-haptics/src/server.ts
+++ b/packages/kit-haptics/src/server.ts
@@ -1,11 +1,11 @@
 import { action, ActionModelState } from '@rise-tools/react'
 import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
 
-type SelectionAction = ActionModelState<'haptics/selection'>
-type ImpactAction = ActionModelState<'haptics/impact', { style: `${ImpactFeedbackStyle}` }>
-type NotificationAction = ActionModelState<
+export type SelectionAction = ActionModelState<'haptics/selection'>
+export type ImpactAction = ActionModelState<'haptics/impact', { style: ImpactFeedbackStyle }>
+export type NotificationAction = ActionModelState<
   'haptics/notification',
-  { type: `${NotificationFeedbackType}` }
+  { type: NotificationFeedbackType }
 >
 
 export function haptics(): ImpactAction

--- a/packages/kit-haptics/tsconfig.json
+++ b/packages/kit-haptics/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "references": [
+    {
+      "path": "../react"
+    }
+  ]
+}

--- a/packages/kit-tamagui-toast/package.json
+++ b/packages/kit-tamagui-toast/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "dependencies": {
     "@rise-tools/react": "0.2.0",
-    "zod": "^3.23.8"
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "@tamagui/toast": "^1.100.3",

--- a/packages/kit-tamagui-toast/package.json
+++ b/packages/kit-tamagui-toast/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "dependencies": {
-    "@rise-tools/react": "0.2.0"
+    "@rise-tools/react": "0.2.0",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
     "@tamagui/toast": "^1.100.3",

--- a/packages/kit-tamagui-toast/src/index.ts
+++ b/packages/kit-tamagui-toast/src/index.ts
@@ -1,13 +1,16 @@
-import type { ActionDefinition } from '@rise-tools/react'
+import type { ActionsDefinition } from '@rise-tools/react'
 import { useToastController } from '@tamagui/toast'
+import z from 'zod'
 
-import type { toast } from './server'
+import type { ToastAction } from './server'
 
-type ToastActions = {
-  toast: ActionDefinition<ReturnType<typeof toast>>
-}
+const ToastActionPayload = z.object({
+  title: z.string(),
+  message: z.string().optional(),
+  duration: z.number().optional(),
+})
 
-export const useToastActions = (): ToastActions => {
+export const useToastActions = (): ActionsDefinition<ToastAction> => {
   const toast = useToastController()
 
   return {
@@ -15,6 +18,7 @@ export const useToastActions = (): ToastActions => {
       action: ({ title, ...options }) => {
         toast.show(title, options)
       },
+      validate: (payload) => ToastActionPayload.parse(payload),
     },
   }
 }

--- a/packages/kit-tamagui-toast/src/index.ts
+++ b/packages/kit-tamagui-toast/src/index.ts
@@ -1,8 +1,7 @@
-import type { ActionsDefinition } from '@rise-tools/react'
 import { useToastController } from '@tamagui/toast'
 import z from 'zod'
 
-import type { ToastAction } from './server'
+import { ToastActions } from './server'
 
 const ToastActionPayload = z.object({
   title: z.string(),
@@ -10,11 +9,11 @@ const ToastActionPayload = z.object({
   duration: z.number().optional(),
 })
 
-export const useToastActions = (): ActionsDefinition<ToastAction> => {
+export const useToastActions = (): ToastActions => {
   const toast = useToastController()
 
   return {
-    toast: {
+    '@rise-tools/kit-tamagui-toast/toast': {
       action: ({ title, ...options }) => {
         toast.show(title, options)
       },

--- a/packages/kit-tamagui-toast/src/server.ts
+++ b/packages/kit-tamagui-toast/src/server.ts
@@ -1,7 +1,11 @@
-import { action, ActionModelState } from '@rise-tools/react'
+import { action, ActionModelState, ActionsDefinition } from '@rise-tools/react'
 
-export type ToastAction = ActionModelState<
-  'toast',
+export type ToastActions = ActionsDefinition<{
+  '@rise-tools/kit-tamagui-toast/toast': ToastAction
+}>
+
+type ToastAction = ActionModelState<
+  '@rise-tools/kit-tamagui-toast/toast',
   {
     title: string
     message?: string
@@ -10,4 +14,4 @@ export type ToastAction = ActionModelState<
 >
 
 export const toast = (title: string, message?: string, duration?: number): ToastAction =>
-  action('toast', { title, message, duration })
+  action('@rise-tools/kit-tamagui-toast/toast', { title, message, duration })

--- a/packages/kit-tamagui-toast/src/server.ts
+++ b/packages/kit-tamagui-toast/src/server.ts
@@ -1,4 +1,13 @@
-import { action } from '@rise-tools/react'
+import { action, ActionModelState } from '@rise-tools/react'
 
-export const toast = (title: string, message?: string, duration?: number) =>
+export type ToastAction = ActionModelState<
+  'toast',
+  {
+    title: string
+    message?: string
+    duration?: number
+  }
+>
+
+export const toast = (title: string, message?: string, duration?: number): ToastAction =>
   action('toast', { title, message, duration })

--- a/packages/kit-tamagui-toast/src/server.ts
+++ b/packages/kit-tamagui-toast/src/server.ts
@@ -1,8 +1,6 @@
 import { action, ActionModelState, ActionsDefinition } from '@rise-tools/react'
 
-export type ToastActions = ActionsDefinition<{
-  '@rise-tools/kit-tamagui-toast/toast': ToastAction
-}>
+export type ToastActions = ActionsDefinition<[ToastAction]>
 
 type ToastAction = ActionModelState<
   '@rise-tools/kit-tamagui-toast/toast',

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -179,7 +179,7 @@ export function Rise({
   path?: string | Path
   modelSource: ModelSource
   components: ComponentRegistry
-  actions?: ActionsDefinition<any>
+  actions?: ActionsDefinition<any[]>
   onEvent?: (event: HandlerEvent) => Promise<ResponseModelState>
 }) {
   if (typeof path === 'string') {

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -1,8 +1,8 @@
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
 
 import {
-  ActionDefinition,
   ActionModelState,
+  ActionsDefinition,
   BaseRise,
   ComponentRegistry,
   HandlerEvent,
@@ -179,7 +179,7 @@ export function Rise({
   path?: string | Path
   modelSource: ModelSource
   components: ComponentRegistry
-  actions?: Record<string, ActionDefinition<any>>
+  actions?: ActionsDefinition<any>
   onEvent?: (event: HandlerEvent) => Promise<ResponseModelState>
 }) {
   if (typeof path === 'string') {
@@ -213,9 +213,14 @@ export function Rise({
       // eslint-disable-next-line
       let { $, name, ...payload } = action
       if (actionDefinition.validate) {
-        payload = actionDefinition.validate(action.payload)
+        try {
+          actionDefinition.action(actionDefinition.validate(payload))
+        } catch (e) {
+          console.error(`Invalid payload for action "${action.name}":`, e)
+        }
+      } else {
+        actionDefinition.action(payload)
       }
-      actionDefinition.action(payload)
     },
     [actions]
   )

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -56,13 +56,14 @@ export type ActionModelState<
   $: 'action'
   name: T
 } & K
+type ActionPayload<T> = Omit<T, '$' | 'name'>
 export type ActionsDefinition<Actions extends Array<ActionModelState>> =
-  Actions extends Array<infer U>
-    ? U extends ActionModelState<infer ActionName, infer ActionPayload>
+  Actions extends Array<infer Action>
+    ? Action extends ActionModelState<infer ActionName>
       ? {
           [Key in ActionName]: {
-            action: (payload: ActionPayload) => void
-            validate?: (args: unknown) => ActionPayload
+            action: (payload: ActionPayload<Action>) => void
+            validate?: (args: unknown) => ActionPayload<Action>
           }
         }
       : never

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext } from 'react'
 
 import { LocalState, useLocalStateValues } from './state'
 import { useStream } from './streams'
+import { UnionToIntersection } from './utils'
 
 /** Components */
 type ComponentIdentifier = string
@@ -57,8 +58,8 @@ export type ActionModelState<
   name: T
 } & K
 export type ActionModelStatePayload<T> = Omit<T, 'name' | '$'>
-export type ActionsDefinition<ActionsMap extends object> =
-  ActionsMap extends ActionModelState<infer Name, infer Action>
+export type ActionsDefinition<ActionDefinition> = UnionToIntersection<
+  ActionDefinition extends ActionModelState<infer Name, infer Action>
     ? {
         [key in Name]: {
           action: (payload: ActionModelStatePayload<Action>) => void
@@ -66,7 +67,7 @@ export type ActionsDefinition<ActionsMap extends object> =
         }
       }
     : never
-
+>
 export type ResponseModelState = {
   $: 'response'
   payload: JSONValue

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -57,8 +57,8 @@ export type ActionModelState<
   name: T
 } & K
 export type ActionModelStatePayload<T> = Omit<T, 'name' | '$'>
-export type ActionsDefinition<Actions extends object> =
-  Actions extends ActionModelState<infer Name, infer Action>
+export type ActionsDefinition<ActionsMap extends object> =
+  ActionsMap extends ActionModelState<infer Name, infer Action>
     ? {
         [key in Name]: {
           action: (payload: ActionModelStatePayload<Action>) => void

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useContext } from 'react'
 
 import { LocalState, useLocalStateValues } from './state'
 import { useStream } from './streams'
-import { UnionToIntersection } from './utils'
 
 /** Components */
 type ComponentIdentifier = string
@@ -58,16 +57,12 @@ export type ActionModelState<
   name: T
 } & K
 export type ActionModelStatePayload<T> = Omit<T, 'name' | '$'>
-export type ActionsDefinition<ActionDefinition> = UnionToIntersection<
-  ActionDefinition extends ActionModelState<infer Name, infer Action>
-    ? {
-        [key in Name]: {
-          action: (payload: ActionModelStatePayload<Action>) => void
-          validate?: (args: unknown) => ActionModelStatePayload<Action>
-        }
-      }
-    : never
->
+export type ActionsDefinition<T> = {
+  [K in keyof T]: {
+    action: (payload: ActionModelStatePayload<T[K]>) => void
+    validate?: (args: unknown) => ActionModelStatePayload<T[K]>
+  }
+}
 export type ResponseModelState = {
   $: 'response'
   payload: JSONValue

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -56,13 +56,17 @@ export type ActionModelState<
   $: 'action'
   name: T
 } & K
-export type ActionModelStatePayload<T> = Omit<T, 'name' | '$'>
-export type ActionsDefinition<T> = {
-  [K in keyof T]: {
-    action: (payload: ActionModelStatePayload<T[K]>) => void
-    validate?: (args: unknown) => ActionModelStatePayload<T[K]>
-  }
-}
+export type ActionsDefinition<Actions extends Array<ActionModelState>> =
+  Actions extends Array<infer U>
+    ? U extends ActionModelState<infer ActionName, infer ActionPayload>
+      ? {
+          [Key in ActionName]: {
+            action: (payload: ActionPayload) => void
+            validate?: (args: unknown) => ActionPayload
+          }
+        }
+      : never
+    : never
 export type ResponseModelState = {
   $: 'response'
   payload: JSONValue

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -57,10 +57,16 @@ export type ActionModelState<
   name: T
 } & K
 export type ActionModelStatePayload<T> = Omit<T, 'name' | '$'>
-export type ActionDefinition<T extends ActionModelState<any, any>> = {
-  action: (payload: ActionModelStatePayload<T>) => void
-  validate?: (args: unknown) => ActionModelStatePayload<T>
-}
+export type ActionsDefinition<Actions extends object> =
+  Actions extends ActionModelState<infer Name, infer Action>
+    ? {
+        [key in Name]: {
+          action: (payload: ActionModelStatePayload<Action>) => void
+          validate?: (args: unknown) => ActionModelStatePayload<Action>
+        }
+      }
+    : never
+
 export type ResponseModelState = {
   $: 'response'
   payload: JSONValue

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -24,3 +24,10 @@ export function lookupValue(value: unknown, ref: (string | number)[]) {
 }
 
 export type MaybeAsync<T> = Promise<T> | T
+
+// Utility type to convert a union to an intersection
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -24,10 +24,3 @@ export function lookupValue(value: unknown, ref: (string | number)[]) {
 }
 
 export type MaybeAsync<T> = Promise<T> | T
-
-// Utility type to convert a union to an intersection
-export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I
-) => void
-  ? I
-  : never

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -23,6 +23,11 @@
     },
     {
       "path": "./packages/kit-expo-router"
+    },
+    {
+      "path": "./packages/kit-tamagui-toast"
+    }, {
+      "path": "./packages/kit-haptics"
     }
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -26,7 +26,8 @@
     },
     {
       "path": "./packages/kit-tamagui-toast"
-    }, {
+    },
+    {
       "path": "./packages/kit-haptics"
     }
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
       "@rise-tools/kit-expo-router/server": ["./packages/kit-expo-router/src/server"],
       "@rise-tools/kit-tamagui-toast": ["./packages/kit-tamagui-toast/src"],
       "@rise-tools/kit-tamagui-toast/server": ["./packages/kit-tamagui-toast/src/server"],
-      "@rise-tools/kit-haptics": ["./packages/kit-expo-router/src"],
+      "@rise-tools/kit-haptics": ["./packages/kit-haptics/src"],
       "@rise-tools/kit-haptics/server": ["./packages/kit-haptics/src/server"],
       "@rise-tools/kit/server": ["./packages/react/src/server"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
       "@rise-tools/kit-expo-router/server": ["./packages/kit-expo-router/src/server"],
       "@rise-tools/kit-tamagui-toast": ["./packages/kit-tamagui-toast/src"],
       "@rise-tools/kit-tamagui-toast/server": ["./packages/kit-tamagui-toast/src/server"],
+      "@rise-tools/kit-haptics": ["./packages/kit-expo-router/src"],
+      "@rise-tools/kit-haptics/server": ["./packages/kit-haptics/src/server"],
       "@rise-tools/kit/server": ["./packages/react/src/server"]
     },
     "composite": true,


### PR DESCRIPTION
Fixes #92 

Validation:
- fix an error when validating action would always throw an error
- add better error message for invalid payloads
- add validators for all actions (in expo router, toast and haptics). In the future, this will be less boilerplate when we use `Typia` (can infer validator from TS type)
- Ensure validator (such as Zod) returns expected shape from `validate` function
- Slightly more convenient `ActionsDefinition` helper