### PR TITLE
feat: add @rise-tools/kit-svg

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "@rise-tools/kit-haptics": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0",
     "@rise-tools/kit-tamagui-toast": "0.2.0",
+    "@rise-tools/kit-svg": "0.2.0",
     "@shopify/react-native-skia": "1.2.3",
     "@tamagui/font-inter": "^1.100.3",
     "@tamagui/react-native-media-driver": "^1.100.3",

--- a/apps/mobile/src/screens/connection.tsx
+++ b/apps/mobile/src/screens/connection.tsx
@@ -1,6 +1,7 @@
 import { RiseComponents } from '@rise-tools/kit'
 import { ExpoRouterComponents, useExpoRouterActions } from '@rise-tools/kit-expo-router'
 import { useHapticsActions } from '@rise-tools/kit-haptics'
+import { SVGComponents } from '@rise-tools/kit-svg'
 import { useToastActions } from '@rise-tools/kit-tamagui-toast'
 import { Rise } from '@rise-tools/react'
 import { TamaguiComponents } from '@rise-tools/tamagui'
@@ -14,6 +15,7 @@ const components = {
   ...TamaguiComponents,
   ...RiseComponents,
   ...ExpoRouterComponents,
+  ...SVGComponents,
 }
 
 export function ConnectionScreen({ connection, path }: { connection: Connection; path?: string }) {

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -35,6 +35,10 @@
     },
     {
       "path": "../../packages/kit-tamagui-toast"
-    }
+    },
+    {
+      "path": "../../packages/kit-svg"
+    },
+    
   ]
 }

--- a/docs/docs/kit/svg.md
+++ b/docs/docs/kit/svg.md
@@ -1,0 +1,10 @@
+# @rise-tools/kit-svg
+
+```sh
+npm install @rise-tools/kit-svg
+```
+
+You must also configure `react-native-svg` in your project. If you're using Expo, run:
+```sh
+npx expo install react-native-svg
+```

--- a/example/demo/package.json
+++ b/example/demo/package.json
@@ -22,6 +22,7 @@
     "@rise-tools/kit": "0.2.0",
     "@rise-tools/kit-haptics": "0.2.0",
     "@rise-tools/kit-tamagui-toast": "0.2.0",
+    "@rise-tools/kit-svg": "0.2.0",
     "@rise-tools/server": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0"
   },

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -7,7 +7,7 @@ import {
 } from '@rise-tools/kit/server'
 import { navigate, StackScreen } from '@rise-tools/kit-expo-router/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
-import { Circle, Svg, SvgCssUri } from '@rise-tools/kit-svg/server'
+import { Circle, Svg, SvgCss, SvgCssUri } from '@rise-tools/kit-svg/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import {
   event,
@@ -73,6 +73,24 @@ function SVGExample() {
           width="100"
           height="100"
           uri="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg"
+          onError={toast('Failed to load SVG from URI')}
+        />
+      </YStack>
+      <YStack>
+        <H4>SVG string</H4>
+        <SvgCss
+          width="100"
+          height="100"
+          xml={`
+            <svg width="32" height="32" viewBox="0 0 32 32">
+              <style>
+                .red {
+                  fill: #ff0000;
+                }
+              </style>
+              <rect class="red" x="0" y="0" width="32" height="32" />
+            </svg>
+          `}
         />
       </YStack>
     </YStack>

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -7,7 +7,7 @@ import {
 } from '@rise-tools/kit/server'
 import { navigate, StackScreen } from '@rise-tools/kit-expo-router/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
-import { Circle, Svg } from '@rise-tools/kit-svg/server'
+import { Circle, Svg, SvgCssUri } from '@rise-tools/kit-svg/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import {
   event,
@@ -60,11 +60,21 @@ function UI() {
 
 function SVGExample() {
   return (
-    <YStack>
-      <H4>SVG</H4>
-      <Svg height="50%" width="50%" viewBox="0 0 100 100">
-        <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
-      </Svg>
+    <YStack gap="$8" padding="$4">
+      <YStack>
+        <H4>SVG</H4>
+        <Svg height="100" width="100" viewBox="0 0 100 100">
+          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+        </Svg>
+      </YStack>
+      <YStack>
+        <H4>SVG from URI</H4>
+        <SvgCssUri
+          width="100"
+          height="100"
+          uri="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg"
+        />
+      </YStack>
     </YStack>
   )
 }

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -7,6 +7,7 @@ import {
 } from '@rise-tools/kit/server'
 import { navigate, StackScreen } from '@rise-tools/kit-expo-router/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
+import { Circle, Svg } from '@rise-tools/kit-svg/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import {
   event,
@@ -36,6 +37,7 @@ export const models = {
   list: ListExample,
   toast: ShowToastExample,
   haptics: HapticsExample,
+  svg: SVGExample,
 }
 
 function UI() {
@@ -50,8 +52,20 @@ function UI() {
         <Button onPress={navigate('list')}>List</Button>
         <Button onPress={navigate('toast')}>Toast</Button>
         <Button onPress={navigate('haptics')}>Haptics</Button>
+        <Button onPress={navigate('svg')}>SVG</Button>
       </YStack>
     </>
+  )
+}
+
+function SVGExample() {
+  return (
+    <YStack>
+      <H4>SVG</H4>
+      <Svg height="50%" width="50%" viewBox="0 0 100 100">
+        <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+      </Svg>
+    </YStack>
   )
 }
 

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -7,8 +7,8 @@ import {
 } from '@rise-tools/kit/server'
 import { navigate, StackScreen } from '@rise-tools/kit-expo-router/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
-import { Circle, Svg, SvgCss, SvgCssUri } from '@rise-tools/kit-svg/server'
 import { openSettings, openURL } from '@rise-tools/kit-linking/server'
+import { Circle, Svg, SvgUri, SvgXml } from '@rise-tools/kit-svg/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import {
   event,
@@ -72,7 +72,7 @@ function SVGExample() {
       </YStack>
       <YStack>
         <H4>SVG from URI</H4>
-        <SvgCssUri
+        <SvgUri
           width="100"
           height="100"
           uri="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg"
@@ -81,17 +81,12 @@ function SVGExample() {
       </YStack>
       <YStack>
         <H4>SVG string</H4>
-        <SvgCss
+        <SvgXml
           width="100"
           height="100"
           xml={`
             <svg width="32" height="32" viewBox="0 0 32 32">
-              <style>
-                .red {
-                  fill: #ff0000;
-                }
-              </style>
-              <rect class="red" x="0" y="0" width="32" height="32" />
+              <rect fill="#ff0000" x="0" y="0" width="32" height="32" />
             </svg>
           `}
         />

--- a/example/demo/tsconfig.json
+++ b/example/demo/tsconfig.json
@@ -15,6 +15,8 @@
   }, {
     "path": "../../packages/kit-tamagui-toast"
   }, {
+    "path": "../../packages/kit-svg"
+  }, {
     "path": "../../packages/server"
   }, {
     "path": "../../packages/kit"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7261,6 +7261,10 @@
       "resolved": "packages/kit-haptics",
       "link": true
     },
+    "node_modules/@rise-tools/kit-svg": {
+      "resolved": "packages/kit-svg",
+      "link": true
+    },
     "node_modules/@rise-tools/kit-tamagui-toast": {
       "resolved": "packages/kit-tamagui-toast",
       "link": true
@@ -33888,6 +33892,17 @@
     },
     "packages/kit-haptics": {
       "name": "@rise-tools/kit-haptics",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rise-tools/react": "0.2.0",
+        "zod": "^3.22.4"
+      },
+      "peerDependencies": {
+        "expo-haptics": "~13.0.1"
+      }
+    },
+    "packages/kit-svg": {
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@rise-tools/kit": "0.2.0",
         "@rise-tools/kit-expo-router": "0.2.0",
         "@rise-tools/kit-haptics": "0.2.0",
+        "@rise-tools/kit-svg": "0.2.0",
         "@rise-tools/kit-tamagui-toast": "0.2.0",
         "@rise-tools/react": "0.2.0",
         "@rise-tools/tamagui": "0.2.0",
@@ -165,6 +166,7 @@
         "@rise-tools/kit": "0.2.0",
         "@rise-tools/kit-expo-router": "0.2.0",
         "@rise-tools/kit-haptics": "0.2.0",
+        "@rise-tools/kit-svg": "0.2.0",
         "@rise-tools/kit-tamagui-toast": "0.2.0",
         "@rise-tools/server": "0.2.0",
         "@rise-tools/tamagui": "0.2.0"
@@ -33903,6 +33905,7 @@
       }
     },
     "packages/kit-svg": {
+      "name": "@rise-tools/kit-svg",
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -33910,7 +33913,7 @@
         "zod": "^3.22.4"
       },
       "peerDependencies": {
-        "expo-haptics": "~13.0.1"
+        "react-native-svg": "15.2.0"
       }
     },
     "packages/kit-tamagui-toast": {

--- a/packages/kit-svg/README.md
+++ b/packages/kit-svg/README.md
@@ -1,0 +1,2 @@
+@rise-tools/kit-svg
+=====

--- a/packages/kit-svg/package.json
+++ b/packages/kit-svg/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rise-tools/kit-svg",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "description": "",
+  "exports": {
+    ".": "./lib/index.js",
+    "./server": "./lib/server.js"
+  },
+  "files": [
+    "src",
+    "lib",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__",
+    "!**/.*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rise-tools/rise-tools.git",
+    "directory": "packages/kit-svg"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Mike Grabowski <grabbou@gmail.com> (https://github.com/grabbou)",
+  "bugs": {
+    "url": "https://github.com/rise-tools/rise-tools/issues"
+  },
+  "homepage": "https://github.com/rise-tools/rise-tools#readme",
+  "dependencies": {
+    "@rise-tools/react": "0.2.0",
+    "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "react-native-svg": "15.2.0"
+  }
+}

--- a/packages/kit-svg/src/index.ts
+++ b/packages/kit-svg/src/index.ts
@@ -1,0 +1,34 @@
+import * as Haptics from 'expo-haptics'
+import z from 'zod'
+
+import type { HapticsActions } from './server'
+
+const ImpactActionPayload = z.object({
+  style: z.nativeEnum(Haptics.ImpactFeedbackStyle).optional(),
+})
+
+const NotificationActionPayload = z.object({
+  type: z.nativeEnum(Haptics.NotificationFeedbackType).optional(),
+})
+
+export const useHapticsActions = (): HapticsActions => {
+  return {
+    '@rise-tools/kit-haptics/impact': {
+      action: ({ style }) => {
+        Haptics.impactAsync(style)
+      },
+      validate: (payload) => ImpactActionPayload.parse(payload),
+    },
+    '@rise-tools/kit-haptics/notification': {
+      action: ({ type }) => {
+        Haptics.notificationAsync(type)
+      },
+      validate: (payload) => NotificationActionPayload.parse(payload),
+    },
+    '@rise-tools/kit-haptics/selection': {
+      action: () => {
+        Haptics.selectionAsync()
+      },
+    },
+  }
+}

--- a/packages/kit-svg/src/index.ts
+++ b/packages/kit-svg/src/index.ts
@@ -1,4 +1,5 @@
 import * as SVG from 'react-native-svg'
+import * as SVGCSS from 'react-native-svg/css'
 
 export const SVGComponents = {
   '@rise-tools/kit-svg/Circle': {
@@ -90,5 +91,17 @@ export const SVGComponents = {
   },
   '@rise-tools/kit-svg/Use': {
     component: SVG.Use,
+  },
+  '@rise-tools/kit-svg/SvgCss': {
+    component: SVGCSS.SvgCss,
+  },
+  '@rise-tools/kit-svg/SvgCssUri': {
+    component: SVGCSS.SvgCssUri,
+  },
+  '@rise-tools/kit-svg/SvgWithCss': {
+    component: SVGCSS.SvgWithCss,
+  },
+  '@rise-tools/kit-svg/SvgWithCssUri': {
+    component: SVGCSS.SvgWithCssUri,
   },
 }

--- a/packages/kit-svg/src/index.ts
+++ b/packages/kit-svg/src/index.ts
@@ -62,21 +62,6 @@ export const SVGComponents = {
   '@rise-tools/kit-svg/Svg': {
     component: SVG.Svg,
   },
-  '@rise-tools/kit-svg/SvgAst': {
-    component: SVG.SvgAst,
-  },
-  '@rise-tools/kit-svg/SvgFromUri': {
-    component: SVG.SvgFromUri,
-  },
-  '@rise-tools/kit-svg/SvgFromXml': {
-    component: SVG.SvgFromXml,
-  },
-  '@rise-tools/kit-svg/SvgUri': {
-    component: SVG.SvgUri,
-  },
-  '@rise-tools/kit-svg/SvgXml': {
-    component: SVG.SvgXml,
-  },
   '@rise-tools/kit-svg/Symbol': {
     component: SVG.Symbol,
   },
@@ -92,16 +77,16 @@ export const SVGComponents = {
   '@rise-tools/kit-svg/Use': {
     component: SVG.Use,
   },
+  '@rise-tools/kit-svg/SvgXml': {
+    component: SVG.SvgXml,
+  },
   '@rise-tools/kit-svg/SvgCss': {
     component: SVGCSS.SvgCss,
   },
+  '@rise-tools/kit-svg/SvgUri': {
+    component: SVG.SvgUri,
+  },
   '@rise-tools/kit-svg/SvgCssUri': {
     component: SVGCSS.SvgCssUri,
-  },
-  '@rise-tools/kit-svg/SvgWithCss': {
-    component: SVGCSS.SvgWithCss,
-  },
-  '@rise-tools/kit-svg/SvgWithCssUri': {
-    component: SVGCSS.SvgWithCssUri,
   },
 }

--- a/packages/kit-svg/src/index.ts
+++ b/packages/kit-svg/src/index.ts
@@ -1,34 +1,94 @@
-import * as Haptics from 'expo-haptics'
-import z from 'zod'
+import * as SVG from 'react-native-svg'
 
-import type { HapticsActions } from './server'
-
-const ImpactActionPayload = z.object({
-  style: z.nativeEnum(Haptics.ImpactFeedbackStyle).optional(),
-})
-
-const NotificationActionPayload = z.object({
-  type: z.nativeEnum(Haptics.NotificationFeedbackType).optional(),
-})
-
-export const useHapticsActions = (): HapticsActions => {
-  return {
-    '@rise-tools/kit-haptics/impact': {
-      action: ({ style }) => {
-        Haptics.impactAsync(style)
-      },
-      validate: (payload) => ImpactActionPayload.parse(payload),
-    },
-    '@rise-tools/kit-haptics/notification': {
-      action: ({ type }) => {
-        Haptics.notificationAsync(type)
-      },
-      validate: (payload) => NotificationActionPayload.parse(payload),
-    },
-    '@rise-tools/kit-haptics/selection': {
-      action: () => {
-        Haptics.selectionAsync()
-      },
-    },
-  }
+export const SVGComponents = {
+  '@rise-tools/kit-svg/Circle': {
+    component: SVG.Circle,
+  },
+  '@rise-tools/kit-svg/ClipPath': {
+    component: SVG.ClipPath,
+  },
+  '@rise-tools/kit-svg/Defs': {
+    component: SVG.Defs,
+  },
+  '@rise-tools/kit-svg/Ellipse': {
+    component: SVG.Ellipse,
+  },
+  '@rise-tools/kit-svg/ForeignObject': {
+    component: SVG.ForeignObject,
+  },
+  '@rise-tools/kit-svg/G': {
+    component: SVG.G,
+  },
+  '@rise-tools/kit-svg/Image': {
+    component: SVG.Image,
+  },
+  '@rise-tools/kit-svg/Line': {
+    component: SVG.Line,
+  },
+  '@rise-tools/kit-svg/LinearGradient': {
+    component: SVG.LinearGradient,
+  },
+  '@rise-tools/kit-svg/Marker': {
+    component: SVG.Marker,
+  },
+  '@rise-tools/kit-svg/Mask': {
+    component: SVG.Mask,
+  },
+  '@rise-tools/kit-svg/Path': {
+    component: SVG.Path,
+  },
+  '@rise-tools/kit-svg/Pattern': {
+    component: SVG.Pattern,
+  },
+  '@rise-tools/kit-svg/Polygon': {
+    component: SVG.Polygon,
+  },
+  '@rise-tools/kit-svg/Polyline': {
+    component: SVG.Polyline,
+  },
+  '@rise-tools/kit-svg/RadialGradient': {
+    component: SVG.RadialGradient,
+  },
+  '@rise-tools/kit-svg/Rect': {
+    component: SVG.Rect,
+  },
+  '@rise-tools/kit-svg/Shape': {
+    component: SVG.Shape,
+  },
+  '@rise-tools/kit-svg/Stop': {
+    component: SVG.Stop,
+  },
+  '@rise-tools/kit-svg/Svg': {
+    component: SVG.Svg,
+  },
+  '@rise-tools/kit-svg/SvgAst': {
+    component: SVG.SvgAst,
+  },
+  '@rise-tools/kit-svg/SvgFromUri': {
+    component: SVG.SvgFromUri,
+  },
+  '@rise-tools/kit-svg/SvgFromXml': {
+    component: SVG.SvgFromXml,
+  },
+  '@rise-tools/kit-svg/SvgUri': {
+    component: SVG.SvgUri,
+  },
+  '@rise-tools/kit-svg/SvgXml': {
+    component: SVG.SvgXml,
+  },
+  '@rise-tools/kit-svg/Symbol': {
+    component: SVG.Symbol,
+  },
+  '@rise-tools/kit-svg/Text': {
+    component: SVG.Text,
+  },
+  '@rise-tools/kit-svg/TextPath': {
+    component: SVG.TextPath,
+  },
+  '@rise-tools/kit-svg/TSpan': {
+    component: SVG.TSpan,
+  },
+  '@rise-tools/kit-svg/Use': {
+    component: SVG.Use,
+  },
 }

--- a/packages/kit-svg/src/server.ts
+++ b/packages/kit-svg/src/server.ts
@@ -1,5 +1,6 @@
 import { createComponentDefinition } from '@rise-tools/react'
 import type * as SVG from 'react-native-svg'
+import type * as SVGCSS from 'react-native-svg/css'
 
 export const Circle = createComponentDefinition<typeof SVG.Circle>('@rise-tools/kit-svg/Circle')
 export const ClipPath = createComponentDefinition<typeof SVG.ClipPath>(
@@ -47,3 +48,14 @@ export const TextPath = createComponentDefinition<typeof SVG.TextPath>(
 )
 export const TSpan = createComponentDefinition<typeof SVG.TSpan>('@rise-tools/kit-svg/TSpan')
 export const Use = createComponentDefinition<typeof SVG.Use>('@rise-tools/kit-svg/Use')
+
+export const SvgCss = createComponentDefinition<typeof SVGCSS.SvgCss>('@rise-tools/kit-svg/SvgCss')
+export const SvgCssUri = createComponentDefinition<typeof SVGCSS.SvgCssUri>(
+  '@rise-tools/kit-svg/SvgCssUri'
+)
+export const SvgWithCss = createComponentDefinition<typeof SVGCSS.SvgWithCss>(
+  '@rise-tools/kit-svg/SvgWithCss'
+)
+export const SvgWithCssUri = createComponentDefinition<typeof SVGCSS.SvgWithCssUri>(
+  '@rise-tools/kit-svg/SvgWithCssUri'
+)

--- a/packages/kit-svg/src/server.ts
+++ b/packages/kit-svg/src/server.ts
@@ -32,15 +32,6 @@ export const Rect = createComponentDefinition<typeof SVG.Rect>('@rise-tools/kit-
 export const Shape = createComponentDefinition<typeof SVG.Shape>('@rise-tools/kit-svg/Shape')
 export const Stop = createComponentDefinition<typeof SVG.Stop>('@rise-tools/kit-svg/Stop')
 export const Svg = createComponentDefinition<typeof SVG.Svg>('@rise-tools/kit-svg/Svg')
-export const SvgAst = createComponentDefinition<typeof SVG.SvgAst>('@rise-tools/kit-svg/SvgAst')
-export const SvgFromUri = createComponentDefinition<typeof SVG.SvgFromUri>(
-  '@rise-tools/kit-svg/SvgFromUri'
-)
-export const SvgFromXml = createComponentDefinition<typeof SVG.SvgFromXml>(
-  '@rise-tools/kit-svg/SvgFromXml'
-)
-export const SvgUri = createComponentDefinition<typeof SVG.SvgUri>('@rise-tools/kit-svg/SvgUri')
-export const SvgXml = createComponentDefinition<typeof SVG.SvgXml>('@rise-tools/kit-svg/SvgXml')
 export const Symbol = createComponentDefinition<typeof SVG.Symbol>('@rise-tools/kit-svg/Symbol')
 export const Text = createComponentDefinition<typeof SVG.Text>('@rise-tools/kit-svg/Text')
 export const TextPath = createComponentDefinition<typeof SVG.TextPath>(
@@ -49,13 +40,10 @@ export const TextPath = createComponentDefinition<typeof SVG.TextPath>(
 export const TSpan = createComponentDefinition<typeof SVG.TSpan>('@rise-tools/kit-svg/TSpan')
 export const Use = createComponentDefinition<typeof SVG.Use>('@rise-tools/kit-svg/Use')
 
+export const SvgXml = createComponentDefinition<typeof SVG.SvgXml>('@rise-tools/kit-svg/SvgXml')
 export const SvgCss = createComponentDefinition<typeof SVGCSS.SvgCss>('@rise-tools/kit-svg/SvgCss')
+
+export const SvgUri = createComponentDefinition<typeof SVG.SvgUri>('@rise-tools/kit-svg/SvgUri')
 export const SvgCssUri = createComponentDefinition<typeof SVGCSS.SvgCssUri>(
   '@rise-tools/kit-svg/SvgCssUri'
-)
-export const SvgWithCss = createComponentDefinition<typeof SVGCSS.SvgWithCss>(
-  '@rise-tools/kit-svg/SvgWithCss'
-)
-export const SvgWithCssUri = createComponentDefinition<typeof SVGCSS.SvgWithCssUri>(
-  '@rise-tools/kit-svg/SvgWithCssUri'
 )

--- a/packages/kit-svg/src/server.ts
+++ b/packages/kit-svg/src/server.ts
@@ -1,0 +1,38 @@
+import { action, ActionModelState, ActionsDefinition } from '@rise-tools/react'
+import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
+
+export type HapticsActions = ActionsDefinition<[ImpactAction, NotificationAction, SelectionAction]>
+
+type SelectionAction = ActionModelState<'@rise-tools/kit-haptics/selection'>
+type ImpactAction = ActionModelState<
+  '@rise-tools/kit-haptics/impact',
+  { style?: ImpactFeedbackStyle }
+>
+type NotificationAction = ActionModelState<
+  '@rise-tools/kit-haptics/notification',
+  { type?: NotificationFeedbackType }
+>
+
+export function haptics(): ImpactAction
+export function haptics(type: 'impact', style?: `${ImpactFeedbackStyle}`): ImpactAction
+export function haptics(
+  type: 'notification',
+  style?: `${NotificationFeedbackType}`
+): NotificationAction
+export function haptics(type: 'selection'): SelectionAction
+
+export function haptics(
+  type: 'impact' | 'notification' | 'selection' = 'impact',
+  style?: `${ImpactFeedbackStyle}` | `${NotificationFeedbackType}`
+) {
+  switch (type) {
+    case 'impact':
+      return action('@rise-tools/kit-haptics/impact', style ? { style } : {})
+    case 'notification':
+      return action('@rise-tools/kit-haptics/notification', style ? { type: style } : {})
+    case 'selection':
+      return action('@rise-tools/kit-haptics/selection')
+    default:
+      throw new Error(`Invalid haptics type: ${type}`)
+  }
+}

--- a/packages/kit-svg/src/server.ts
+++ b/packages/kit-svg/src/server.ts
@@ -1,38 +1,49 @@
-import { action, ActionModelState, ActionsDefinition } from '@rise-tools/react'
-import type { ImpactFeedbackStyle, NotificationFeedbackType } from 'expo-haptics'
+import { createComponentDefinition } from '@rise-tools/react'
+import type * as SVG from 'react-native-svg'
 
-export type HapticsActions = ActionsDefinition<[ImpactAction, NotificationAction, SelectionAction]>
-
-type SelectionAction = ActionModelState<'@rise-tools/kit-haptics/selection'>
-type ImpactAction = ActionModelState<
-  '@rise-tools/kit-haptics/impact',
-  { style?: ImpactFeedbackStyle }
->
-type NotificationAction = ActionModelState<
-  '@rise-tools/kit-haptics/notification',
-  { type?: NotificationFeedbackType }
->
-
-export function haptics(): ImpactAction
-export function haptics(type: 'impact', style?: `${ImpactFeedbackStyle}`): ImpactAction
-export function haptics(
-  type: 'notification',
-  style?: `${NotificationFeedbackType}`
-): NotificationAction
-export function haptics(type: 'selection'): SelectionAction
-
-export function haptics(
-  type: 'impact' | 'notification' | 'selection' = 'impact',
-  style?: `${ImpactFeedbackStyle}` | `${NotificationFeedbackType}`
-) {
-  switch (type) {
-    case 'impact':
-      return action('@rise-tools/kit-haptics/impact', style ? { style } : {})
-    case 'notification':
-      return action('@rise-tools/kit-haptics/notification', style ? { type: style } : {})
-    case 'selection':
-      return action('@rise-tools/kit-haptics/selection')
-    default:
-      throw new Error(`Invalid haptics type: ${type}`)
-  }
-}
+export const Circle = createComponentDefinition<typeof SVG.Circle>('@rise-tools/kit-svg/Circle')
+export const ClipPath = createComponentDefinition<typeof SVG.ClipPath>(
+  '@rise-tools/kit-svg/ClipPath'
+)
+export const Defs = createComponentDefinition<typeof SVG.Defs>('@rise-tools/kit-svg/Defs')
+export const Ellipse = createComponentDefinition<typeof SVG.Ellipse>('@rise-tools/kit-svg/Ellipse')
+export const ForeignObject = createComponentDefinition<typeof SVG.ForeignObject>(
+  '@rise-tools/kit-svg/ForeignObject'
+)
+export const G = createComponentDefinition<typeof SVG.G>('@rise-tools/kit-svg/G')
+export const Image = createComponentDefinition<typeof SVG.Image>('@rise-tools/kit-svg/Image')
+export const Line = createComponentDefinition<typeof SVG.Line>('@rise-tools/kit-svg/Line')
+export const LinearGradient = createComponentDefinition<typeof SVG.LinearGradient>(
+  '@rise-tools/kit-svg/LinearGradient'
+)
+export const Marker = createComponentDefinition<typeof SVG.Marker>('@rise-tools/kit-svg/Marker')
+export const Mask = createComponentDefinition<typeof SVG.Mask>('@rise-tools/kit-svg/Mask')
+export const Path = createComponentDefinition<typeof SVG.Path>('@rise-tools/kit-svg/Path')
+export const Pattern = createComponentDefinition<typeof SVG.Pattern>('@rise-tools/kit-svg/Pattern')
+export const Polygon = createComponentDefinition<typeof SVG.Polygon>('@rise-tools/kit-svg/Polygon')
+export const Polyline = createComponentDefinition<typeof SVG.Polyline>(
+  '@rise-tools/kit-svg/Polyline'
+)
+export const RadialGradient = createComponentDefinition<typeof SVG.RadialGradient>(
+  '@rise-tools/kit-svg/RadialGradient'
+)
+export const Rect = createComponentDefinition<typeof SVG.Rect>('@rise-tools/kit-svg/Rect')
+export const Shape = createComponentDefinition<typeof SVG.Shape>('@rise-tools/kit-svg/Shape')
+export const Stop = createComponentDefinition<typeof SVG.Stop>('@rise-tools/kit-svg/Stop')
+export const Svg = createComponentDefinition<typeof SVG.Svg>('@rise-tools/kit-svg/Svg')
+export const SvgAst = createComponentDefinition<typeof SVG.SvgAst>('@rise-tools/kit-svg/SvgAst')
+export const SvgFromUri = createComponentDefinition<typeof SVG.SvgFromUri>(
+  '@rise-tools/kit-svg/SvgFromUri'
+)
+export const SvgFromXml = createComponentDefinition<typeof SVG.SvgFromXml>(
+  '@rise-tools/kit-svg/SvgFromXml'
+)
+export const SvgUri = createComponentDefinition<typeof SVG.SvgUri>('@rise-tools/kit-svg/SvgUri')
+export const SvgXml = createComponentDefinition<typeof SVG.SvgXml>('@rise-tools/kit-svg/SvgXml')
+export const Symbol = createComponentDefinition<typeof SVG.Symbol>('@rise-tools/kit-svg/Symbol')
+export const Text = createComponentDefinition<typeof SVG.Text>('@rise-tools/kit-svg/Text')
+export const TextPath = createComponentDefinition<typeof SVG.TextPath>(
+  '@rise-tools/kit-svg/TextPath'
+)
+export const TSpan = createComponentDefinition<typeof SVG.TSpan>('@rise-tools/kit-svg/TSpan')
+export const Use = createComponentDefinition<typeof SVG.Use>('@rise-tools/kit-svg/Use')

--- a/packages/kit-svg/tsconfig.json
+++ b/packages/kit-svg/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "references": [
+    {
+      "path": "../react"
+    }
+  ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -29,6 +29,9 @@
     },
     {
       "path": "./packages/kit-haptics"
+    },
+    {
+      "path": "./packages/kit-svg"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
       "@rise-tools/kit-haptics": ["./packages/kit-haptics/src"],
       "@rise-tools/kit-haptics/server": ["./packages/kit-haptics/src/server"],
       "@rise-tools/kit-svg": ["./packages/kit-svg/src"],
-      "@rise-tools/kit-svg/server": ["./packages/kit-svg/src/server"]
+      "@rise-tools/kit-svg/server": ["./packages/kit-svg/src/server"],
       "@rise-tools/kit-linking": ["./packages/kit-linking/src"],
       "@rise-tools/kit-linking/server": ["./packages/kit-linking/src/server"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
       "@rise-tools/kit-tamagui-toast": ["./packages/kit-tamagui-toast/src"],
       "@rise-tools/kit-tamagui-toast/server": ["./packages/kit-tamagui-toast/src/server"],
       "@rise-tools/kit-haptics": ["./packages/kit-haptics/src"],
-      "@rise-tools/kit-haptics/server": ["./packages/kit-haptics/src/server"]
+      "@rise-tools/kit-haptics/server": ["./packages/kit-haptics/src/server"],
+      "@rise-tools/kit-svg": ["./packages/kit-svg/src"],
+      "@rise-tools/kit-svg/server": ["./packages/kit-svg/src/server"]
     },
     "composite": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Fixes #97 

Adds `react-native-svg` supported by latest Expo SDK.

The example is quite ugly, but I just copied some examples from React Native SVG to demonstrate various functionality

- static SVG
- SVG from URI
- SVG as string

<img src="https://github.com/rise-tools/rise-tools/assets/2464966/73775268-d24f-453b-95d1-0b37038dcdc3" width="200" />

This is great opportunity to get creative and include some fun stuff, so let's get creative!
