### PR TITLE
feat: add "@rise-tools/kit-lucide-icons"

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "@rise-tools/kit-haptics": "0.2.0",
     "@rise-tools/kit-forms": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0",
+    "@rise-tools/kit-lucide-icons": "0.2.0",
     "@rise-tools/kit-tamagui-toast": "0.2.0",
     "@rise-tools/kit-svg": "0.2.0",
     "@rise-tools/kit-linking": "0.2.0",

--- a/apps/mobile/src/screens/connection.tsx
+++ b/apps/mobile/src/screens/connection.tsx
@@ -2,8 +2,9 @@ import { RiseComponents } from '@rise-tools/kit'
 import { ExpoRouterComponents, useExpoRouterActions } from '@rise-tools/kit-expo-router'
 import { FormComponents } from '@rise-tools/kit-forms'
 import { useHapticsActions } from '@rise-tools/kit-haptics'
-import { SVGComponents } from '@rise-tools/kit-svg'
 import { useLinkingActions } from '@rise-tools/kit-linking'
+import { LucideIconsComponents } from '@rise-tools/kit-lucide-icons'
+import { SVGComponents } from '@rise-tools/kit-svg'
 import { useToastActions } from '@rise-tools/kit-tamagui-toast'
 import { Rise } from '@rise-tools/react'
 import { TamaguiComponents } from '@rise-tools/tamagui'
@@ -19,6 +20,7 @@ const components = {
   ...ExpoRouterComponents,
   ...FormComponents,
   ...SVGComponents,
+  ...LucideIconsComponents,
 }
 
 export function ConnectionScreen({ connection, path }: { connection: Connection; path?: string }) {

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../../packages/kit-tamagui-toast"
     },
     {
+      "path": "../../packages/kit-lucide-icons"
+    },
+    {
       "path": "../../packages/kit-forms"
     },
     {

--- a/docs/docs/kit/icons.md
+++ b/docs/docs/kit/icons.md
@@ -1,0 +1,9 @@
+# @rise-tools/kit-lucide-icons
+
+```sh 
+npm install @rise-tools/kit-lucide-icons @tamagui/lucide-icons react-native-svg
+```
+
+## Components
+
+- `LucideIcon` 

--- a/docs/docs/kit/index.md
+++ b/docs/docs/kit/index.md
@@ -42,3 +42,5 @@ import useToastActions from '@rise-tools/kit-linking'
 
 ### Linking
 
+### Lucide Icons
+

--- a/example/demo/package.json
+++ b/example/demo/package.json
@@ -24,6 +24,7 @@
     "@rise-tools/kit-forms": "0.2.0",
     "@rise-tools/kit-linking": "0.2.0",
     "@rise-tools/kit-tamagui-toast": "0.2.0",
+    "@rise-tools/kit-lucide-icons": "0.2.0",
     "@rise-tools/kit-svg": "0.2.0",
     "@rise-tools/server": "0.2.0",
     "@rise-tools/kit-expo-router": "0.2.0"

--- a/example/demo/src/delivery/ui.tsx
+++ b/example/demo/src/delivery/ui.tsx
@@ -1,6 +1,6 @@
-import { Icon as LucideIcon } from '@rise-tools/kit/server'
 import { navigate, StackScreen } from '@rise-tools/kit-expo-router/server'
 import { openURL } from '@rise-tools/kit-linking/server'
+import { LucideIcon } from '@rise-tools/kit-lucide-icons/server'
 import { Button, Circle, H3, Theme, XStack, YStack } from '@rise-tools/tamagui/server'
 export const models = {
   delivery: UI,

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -18,7 +18,7 @@ import { LucideIcon } from '@rise-tools/kit-lucide-icons/server'
 import { Circle, Svg, SvgUri, SvgXml } from '@rise-tools/kit-svg/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import { localStateExperimental, response, setStateAction } from '@rise-tools/react'
-import { Button, H4, ScrollView, Text, YStack } from '@rise-tools/tamagui/server'
+import { Button, H4, ScrollView, Text, XStack, YStack } from '@rise-tools/tamagui/server'
 
 export const models = {
   controls: UI,
@@ -53,11 +53,23 @@ function LucideIconsExample() {
     <YStack gap="$8" padding="$4">
       <YStack gap="$2">
         <H4>Default size</H4>
-        <LucideIcon icon="Github" />
+        <XStack gap="$2">
+          <LucideIcon icon="PocketKnife" />
+          <LucideIcon icon="HeartHandshake" />
+          <LucideIcon icon="Sunrise" />
+          <LucideIcon icon="Flame" />
+          <LucideIcon icon="Rocket" />
+        </XStack>
       </YStack>
       <YStack gap="$2">
         <H4>Custom size</H4>
-        <LucideIcon icon="Github" size={64} />
+        <XStack gap="$2">
+          <LucideIcon icon="PocketKnife" size={60} />
+          <LucideIcon icon="HeartHandshake" size={60} />
+          <LucideIcon icon="Sunrise" size={60} />
+          <LucideIcon icon="Flame" size={60} />
+          <LucideIcon icon="Rocket" size={60} />
+        </XStack>
       </YStack>
     </YStack>
   )

--- a/example/demo/src/ui-controls/ui.tsx
+++ b/example/demo/src/ui-controls/ui.tsx
@@ -14,6 +14,7 @@ import {
 } from '@rise-tools/kit-forms/server'
 import { haptics } from '@rise-tools/kit-haptics/server'
 import { openSettings, openURL } from '@rise-tools/kit-linking/server'
+import { LucideIcon } from '@rise-tools/kit-lucide-icons/server'
 import { Circle, Svg, SvgUri, SvgXml } from '@rise-tools/kit-svg/server'
 import { toast } from '@rise-tools/kit-tamagui-toast/server'
 import { localStateExperimental, response, setStateAction } from '@rise-tools/react'
@@ -26,6 +27,7 @@ export const models = {
   toast: ShowToastExample,
   haptics: HapticsExample,
   svg: SVGExample,
+  icons: LucideIconsExample,
   linking: LinkingExample,
 }
 
@@ -39,9 +41,25 @@ function UI() {
         <Button onPress={navigate('toast')}>Toast</Button>
         <Button onPress={navigate('haptics')}>Haptics</Button>
         <Button onPress={navigate('svg')}>SVG</Button>
+        <Button onPress={navigate('icons')}>Icons</Button>
         <Button onPress={navigate('linking')}>Linking</Button>
       </YStack>
     </>
+  )
+}
+
+function LucideIconsExample() {
+  return (
+    <YStack gap="$8" padding="$4">
+      <YStack gap="$2">
+        <H4>Default size</H4>
+        <LucideIcon icon="Github" />
+      </YStack>
+      <YStack gap="$2">
+        <H4>Custom size</H4>
+        <LucideIcon icon="Github" size={64} />
+      </YStack>
+    </YStack>
   )
 }
 

--- a/example/demo/tsconfig.json
+++ b/example/demo/tsconfig.json
@@ -17,6 +17,8 @@
   }, {
     "path": "../../packages/kit-tamagui-toast"
   }, {
+    "path": "../../packages/kit-lucide-icons"
+  }, {
     "path": "../../packages/kit-linking"
   }, {
     "path": "../../packages/kit-svg"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "jest": "^28.1.1",
         "jest-environment-jsdom": "^29.7.0",
-        "patch-package": "^8.0.0",
         "prettier": "^3.2.5",
         "release-it": "^15.4.1",
         "typescript": "^5.1.3"
@@ -59,6 +58,7 @@
         "@rise-tools/kit-forms": "0.2.0",
         "@rise-tools/kit-haptics": "0.2.0",
         "@rise-tools/kit-linking": "0.2.0",
+        "@rise-tools/kit-lucide-icons": "0.2.0",
         "@rise-tools/kit-svg": "0.2.0",
         "@rise-tools/kit-tamagui-toast": "0.2.0",
         "@rise-tools/react": "0.2.0",
@@ -171,6 +171,7 @@
         "@rise-tools/kit-forms": "0.2.0",
         "@rise-tools/kit-haptics": "0.2.0",
         "@rise-tools/kit-linking": "0.2.0",
+        "@rise-tools/kit-lucide-icons": "0.2.0",
         "@rise-tools/kit-svg": "0.2.0",
         "@rise-tools/kit-tamagui-toast": "0.2.0",
         "@rise-tools/server": "0.2.0",
@@ -7276,6 +7277,10 @@
       "resolved": "packages/kit-linking",
       "link": true
     },
+    "node_modules/@rise-tools/kit-lucide-icons": {
+      "resolved": "packages/kit-lucide-icons",
+      "link": true
+    },
     "node_modules/@rise-tools/kit-svg": {
       "resolved": "packages/kit-svg",
       "link": true
@@ -10180,12 +10185,6 @@
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "license": "Apache-2.0"
-    },
-    "node_modules/@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
@@ -21247,24 +21246,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.5",
-        "isarray": "^2.0.5",
-        "jsonify": "^0.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "devOptional": true,
@@ -21293,15 +21274,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonparse": {
@@ -21339,15 +21311,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -26273,101 +26236,6 @@
       "dependencies": {
         "ansi-escapes": "^4.3.2",
         "cross-spawn": "^7.0.3"
-      }
-    },
-    "node_modules/patch-package": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
-      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
-      "dev": true,
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.7.0",
-        "cross-spawn": "^7.0.3",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
-        "json-stable-stringify": "^1.0.2",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.6",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^7.5.3",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">5"
-      }
-    },
-    "node_modules/patch-package/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/patch-package/node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "dev": true,
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/patch-package/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/patch-package/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/patch-package/node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -34077,6 +33945,18 @@
       },
       "peerDependencies": {
         "expo-linking": "~6.3.1"
+      }
+    },
+    "packages/kit-lucide-icons": {
+      "name": "@rise-tools/kit-lucide-icons",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rise-tools/react": "0.2.0",
+        "zod": "^3.22.4"
+      },
+      "peerDependencies": {
+        "@tamagui/lucide-icons": "^1.100.3"
       }
     },
     "packages/kit-svg": {

--- a/packages/kit-lucide-icons/README.md
+++ b/packages/kit-lucide-icons/README.md
@@ -1,0 +1,2 @@
+@rise-tools/kit-lucide-icons
+=====

--- a/packages/kit-lucide-icons/package.json
+++ b/packages/kit-lucide-icons/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rise-tools/kit-lucide-icons",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "description": "",
+  "exports": {
+    ".": "./lib/index.js",
+    "./server": "./lib/server.js"
+  },
+  "files": [
+    "src",
+    "lib",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__",
+    "!**/.*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rise-tools/rise-tools.git",
+    "directory": "packages/kit-lucide-icons"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Mike Grabowski <grabbou@gmail.com> (https://github.com/grabbou)",
+  "bugs": {
+    "url": "https://github.com/rise-tools/rise-tools/issues"
+  },
+  "homepage": "https://github.com/rise-tools/rise-tools#readme",
+  "dependencies": {
+    "@rise-tools/react": "0.2.0",
+    "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@tamagui/lucide-icons": "^1.100.3"
+  }
+}

--- a/packages/kit-lucide-icons/src/index.tsx
+++ b/packages/kit-lucide-icons/src/index.tsx
@@ -1,15 +1,18 @@
 import type { IconProps } from '@tamagui/helpers-icon'
 import * as LucideIcons from '@tamagui/lucide-icons'
+import React from 'react'
 import { SizableText } from 'tamagui'
 
-export function LucideIcon({
-  icon,
-  size = 20,
-  ...rest
-}: IconProps & { icon: keyof typeof LucideIcons }) {
+export function Icon({ icon, size = 20, ...rest }: IconProps & { icon: keyof typeof LucideIcons }) {
   const IconComponent = LucideIcons[icon]
   if (IconComponent) {
     return <IconComponent size={size} {...rest} />
   }
   return <SizableText>Icon not found</SizableText>
+}
+
+export const LucideIconsComponents = {
+  '@rise-tools/kit-lucide-icons/Icon': {
+    component: Icon,
+  },
 }

--- a/packages/kit-lucide-icons/src/server.ts
+++ b/packages/kit-lucide-icons/src/server.ts
@@ -1,0 +1,7 @@
+import { createComponentDefinition } from '@rise-tools/react'
+
+import { Icon } from '.'
+
+export const LucideIcon = createComponentDefinition<typeof Icon>(
+  '@rise-tools/kit-lucide-icons/Icon'
+)

--- a/packages/kit-lucide-icons/tsconfig.json
+++ b/packages/kit-lucide-icons/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "references": [
+    {
+      "path": "../react"
+    }
+  ]
+}

--- a/packages/kit/src/index.tsx
+++ b/packages/kit/src/index.tsx
@@ -1,7 +1,6 @@
 import QRCode from 'react-native-qrcode-svg'
 
 import { RNDraggableFlatList } from './client/DraggableFlatList'
-import { LucideIcon } from './client/Icon'
 
 export const RiseComponents = {
   RNDraggableFlatList: {
@@ -9,8 +8,5 @@ export const RiseComponents = {
   },
   RNQRCode: {
     component: QRCode,
-  },
-  LucideIcon: {
-    component: LucideIcon,
   },
 }

--- a/packages/kit/src/server/bindings.ts
+++ b/packages/kit/src/server/bindings.ts
@@ -2,10 +2,8 @@ import { createComponentDefinition } from '@rise-tools/react'
 import type RNQRCode from 'react-native-qrcode-svg'
 
 import type { RNDraggableFlatList } from '../client/DraggableFlatList'
-import type { LucideIcon } from '../client/Icon'
 
 /** Bindings to client-side components */
 export const QRCode = createComponentDefinition<typeof RNQRCode>('RNQRCode')
 export const DraggableFlatList =
   createComponentDefinition<typeof RNDraggableFlatList>('RNDraggableFlatList')
-export const Icon = createComponentDefinition<typeof LucideIcon>('LucideIcon')

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "./packages/kit-linking"
+    },
+    {
+      "path": "./packages/kit-lucide-icons"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
       "@rise-tools/kit-expo-router/server": ["./packages/kit-expo-router/src/server"],
       "@rise-tools/kit-tamagui-toast": ["./packages/kit-tamagui-toast/src"],
       "@rise-tools/kit-tamagui-toast/server": ["./packages/kit-tamagui-toast/src/server"],
+      "@rise-tools/kit-lucide-icons": ["./packages/kit-lucide-icons/src"],
+      "@rise-tools/kit-lucide-icons/server": ["./packages/kit-lucide-icons/src/server"],
       "@rise-tools/kit-haptics": ["./packages/kit-haptics/src"],
       "@rise-tools/kit-haptics/server": ["./packages/kit-haptics/src/server"],
       "@rise-tools/kit-forms": ["./packages/kit-forms/src"],


### PR DESCRIPTION
Moving components from "kit" to prepare it for being umbrella.

<img src="https://github.com/rise-tools/rise-tools/assets/2464966/1d5938a5-de3b-42bc-8927-747829af2374" width="300" />
