### PR TITLE
fix: view model update when subscribed

### DIFF
--- a/packages/server/src/__tests__/model-view.test.ts
+++ b/packages/server/src/__tests__/model-view.test.ts
@@ -70,4 +70,23 @@ describe('view models', () => {
     await waitToHaveBeenCalled(2)
     expect(mult.get()).toBe(9)
   })
+  test('view updates only once when two deps change', async () => {
+    const [a, setA] = state(2)
+    const [b, setB] = state(3)
+    const mult = view((get) => {
+      const _a = get(a)
+      const _b = get(b)
+      if (!_a || !_b) return 0
+      return _a * _b
+    })
+    const [handler, waitToHaveBeenCalled] = createWaitableMock()
+    const firstCall = waitToHaveBeenCalled(1)
+    mult.subscribe(handler)
+    await firstCall
+    setA(3)
+    setB(4)
+    await waitToHaveBeenCalled(2)
+    expect(mult.get()).toBe(12)
+    expect(handler).toBeCalledTimes(2)
+  })
 })

--- a/packages/server/src/__tests__/model-view.test.ts
+++ b/packages/server/src/__tests__/model-view.test.ts
@@ -1,5 +1,6 @@
 import { state } from '../model-state'
 import { view } from '../model-view'
+import { createWaitableMock } from './test-utils'
 
 describe('view models', () => {
   test('basic view get/set', async () => {
@@ -51,5 +52,22 @@ describe('view models', () => {
     mult.subscribe(handler)
     setA(3)
     expect(await mult.load()).toBe(9)
+  })
+  test('view updates when deps change', async () => {
+    const [a, setA] = state(2)
+    const [b] = state(3)
+    const mult = view((get) => {
+      const _a = get(a)
+      const _b = get(b)
+      if (!_a || !_b) return 0
+      return _a * _b
+    })
+    const [handler, waitToHaveBeenCalled] = createWaitableMock()
+    const firstCall = waitToHaveBeenCalled(1)
+    mult.subscribe(handler)
+    await firstCall
+    setA(3)
+    await waitToHaveBeenCalled(2)
+    expect(mult.get()).toBe(9)
   })
 })


### PR DESCRIPTION
View model was not firing subscription updates when the dependency changes. This was never implemented.

Using a timeout(1) to handle cases when two view dependencies change, we only want to trigger one update