### PR TITLE
feat: add prompt skip flag

### DIFF
--- a/packages/create-rise/package.json
+++ b/packages/create-rise/package.json
@@ -23,7 +23,8 @@
   "type": "module",
   "author": "Arpit Bhalla (https://github.com/arpitBhalla)",
   "contributors": [
-    "Mike Grabowski <grabbou@gmail.com> (https://github.com/grabbou)"
+    "Mike Grabowski <grabbou@gmail.com> (https://github.com/grabbou)",
+    "Piotr Kochanowski (https://github.com/TheKohan)"
   ],
   "bugs": {
     "url": "https://github.com/rise-tools/rise-tools/issues"

--- a/packages/create-rise/src/cli.ts
+++ b/packages/create-rise/src/cli.ts
@@ -15,19 +15,24 @@ type Options = {
   verbose: boolean
   install: boolean
   help: boolean
+  yes: boolean
 }
 
 const RISE_ASCII =
   '\r\n\u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\r\n\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255D\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255D\r\n\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255D\u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2557  \r\n\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551\u255A\u2550\u2550\u2550\u2550\u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u255D  \r\n\u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\r\n\u255A\u2550\u255D  \u255A\u2550\u255D\u255A\u2550\u255D\u255A\u2550\u2550\u2550\u2550\u2550\u2550\u255D\u255A\u2550\u2550\u2550\u2550\u2550\u2550\u255D\r\n                           \r\n'
+const DEFAULT_PROJECT_NAME = 'rise-project'
 
 async function createRise(opts: Options) {
   console.log(gradient(RISE_ASCII))
 
-  const projectName = await input({
-    message: 'Project Name',
-    default: 'rise-project',
-    theme: prompt,
-  })
+  let projectName = DEFAULT_PROJECT_NAME
+  if (!opts.yes) {
+    projectName = await input({
+      message: 'Project Name',
+      default: DEFAULT_PROJECT_NAME,
+      theme: prompt,
+    })
+  }
 
   const template = '@rise-tools/template-blank-playground'
 
@@ -43,17 +48,20 @@ async function createRise(opts: Options) {
       throw e
     }
 
-    const overwrite = await confirm({
-      message: 'Target directory is not empty. Would you like to remove it and proceed?',
-      theme: prompt,
-    })
+    if (!opts.yes) {
+      const overwrite = await confirm({
+        message: 'Target directory is not empty. Would you like to remove it and proceed?',
+        theme: prompt,
+      })
 
-    if (!overwrite) {
-      console.error(dedent`
-        ${debug(`The directory "${root}" already exists. Exiting...`)}
-      `)
-      return
+      if (!overwrite) {
+        console.error(dedent`
+          ${debug(`The directory "${root}" already exists. Exiting...`)}
+        `)
+        return
+      }
     }
+
     await fs.rm(root, { recursive: true, force: true })
     await fs.mkdir(root)
   }
@@ -116,15 +124,17 @@ async function copyAdditionalTemplateFiles(root: string) {
 }
 
 const opts = minimist<Options>(process.argv.slice(2), {
-  boolean: ['verbose', 'install', 'help'],
+  boolean: ['verbose', 'install', 'help', 'yes'],
   default: {
     verbose: false,
     install: true,
     help: false,
+    yes: false,
   },
   alias: {
     v: 'verbose',
     h: 'help',
+    y: 'yes',
   },
 })
 
@@ -140,6 +150,7 @@ if (opts.help) {
       --no-install         Skip installing npm packages
       -v, --verbose        Print additional logs
       -h, --help           Usage info
+      -y, --yes            Use the default options for creating a project
   `)
   process.exit(0)
 }

--- a/packages/create-rise/src/cli.ts
+++ b/packages/create-rise/src/cli.ts
@@ -115,6 +115,14 @@ async function createRise(opts: Options) {
   }
 
   console.log(highlight('npm run dev'))
+
+  console.log()
+
+  console.log(dedent`
+    ${bold('📱 For fast and easy prototyping check out Rise Playground App!')}
+    ${highlight('iOS')}     ${chalk.underline('https://apps.apple.com/us/app/rise-playground/id6499588861')}
+    ${highlight('Android')} ${chalk.underline('https://play.google.com/store/apps/details?id=com.xplatlabs.rise')}
+  `)
 }
 
 async function copyAdditionalTemplateFiles(root: string) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c1e9ccb0-a411-4bbb-b791-70ea1d636b35)

Small PR that introduces `--yes` flag to `create-rise`, to comply with requirements of fully automated scenario.
* also additional encouragement to download `rise-playground`!