### PR TITLE
feat: type safety for `navigate` action in React Navigation 

### DIFF
--- a/docs/docs/kit/react-navigation.md
+++ b/docs/docs/kit/react-navigation.md
@@ -24,3 +24,33 @@ To see an example client implementation that uses React Navigation, see the [sou
 ### `StackScreen`
 
 https://reactnavigation.org/docs/stack-navigator/#options
+
+## Type checking with TypeScript
+
+Place the following code in your project, next to your server-side models:
+
+```ts
+import '@rise-tools/kit-react-navigation/server'
+declare module '@rise-tools/kit-react-navigation/server' {
+  interface Navigate {
+    // your server-defined and local screens go here
+    screens: {
+      // no params
+      home: void
+      // with params
+      profile: { user: string }
+      // with optional params
+      help: { sessionId: string } | undefined
+    }
+  }
+}
+```
+
+This will provide type-safety, when calling navigate:
+
+```ts
+navigate('home')
+navigate('profile', { params: { user: 'Mike' }})
+navigate('help')
+navigate('help', { params: { sessionId: '<<hash>>' }})
+```

--- a/example/demo/src/index.ts
+++ b/example/demo/src/index.ts
@@ -13,6 +13,6 @@ createWSServer(models, port)
 import '@rise-tools/kit-react-navigation/server'
 declare module '@rise-tools/kit-react-navigation/server' {
   interface Navigate {
-    path: keyof typeof models
+    screens: Record<keyof typeof models, void>
   }
 }

--- a/example/demo/src/index.ts
+++ b/example/demo/src/index.ts
@@ -1,5 +1,3 @@
-import '@rise-tools/kit-react-navigation/server'
-
 import { createWSServer } from '@rise-tools/server'
 
 import { models as delivery } from './delivery/ui.js'
@@ -11,3 +9,10 @@ const models = { ...inventory, ...controls, ...delivery }
 const port = Number(process.env.PORT || '3005')
 
 createWSServer(models, port)
+
+import '@rise-tools/kit-react-navigation/server'
+declare module '@rise-tools/kit-react-navigation/server' {
+  interface Navigate {
+    path: keyof typeof models
+  }
+}

--- a/packages/kit-react-navigation/src/server.ts
+++ b/packages/kit-react-navigation/src/server.ts
@@ -6,8 +6,18 @@ export type ReactNavigationActions = ActionsDefinition<
   [ReturnType<typeof navigate>, ReturnType<typeof goBack>]
 >
 
-export const navigate = (path: Path<Navigate>) =>
-  action('rise-tools/kit-react-navigation/navigate', { path })
+type NavigateOptions = {
+  screen?: {
+    title?: string
+  }
+}
+
+export const navigate = <T extends keyof Path<Navigate>, Params extends Path<Navigate>[T]>(
+  path: T,
+  ...[options]: Params extends void
+    ? [opts?: NavigateOptions]
+    : [opts: NavigateOptions & { params: Params }]
+) => action('rise-tools/kit-react-navigation/navigate', { path, options })
 
 export const goBack = () => action('rise-tools/kit-react-navigation/goBack')
 
@@ -15,6 +25,6 @@ export const StackScreen = createComponentDefinition<typeof Screen>(
   'rise-tools/kit-react-navigation/StackScreen'
 )
 
-type Path<T> = 'path' extends keyof T ? T['path'] : string
+type Path<T> = 'screens' extends keyof T ? T['screens'] : Record<string, any>
 
 export interface Navigate {}

--- a/packages/kit-react-navigation/src/server.ts
+++ b/packages/kit-react-navigation/src/server.ts
@@ -6,14 +6,7 @@ export type ReactNavigationActions = ActionsDefinition<
   [ReturnType<typeof navigate>, ReturnType<typeof goBack>]
 >
 
-type PathType<T> = 'path' extends keyof T ? T['path'] : string
-
-export interface Navigate {}
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-type AnyString = string & {}
-
-export const navigate = (path: PathType<Navigate> | AnyString) =>
+export const navigate = (path: Path<Navigate>) =>
   action('rise-tools/kit-react-navigation/navigate', { path })
 
 export const goBack = () => action('rise-tools/kit-react-navigation/goBack')
@@ -22,4 +15,6 @@ export const StackScreen = createComponentDefinition<typeof Screen>(
   'rise-tools/kit-react-navigation/StackScreen'
 )
 
-navigate('')
+type Path<T> = 'path' extends keyof T ? T['path'] : string
+
+export interface Navigate {}

--- a/packages/kit-react-navigation/src/server.ts
+++ b/packages/kit-react-navigation/src/server.ts
@@ -15,8 +15,13 @@ type NavigateOptions = {
 export const navigate = <T extends keyof Path<Navigate>, Params extends Path<Navigate>[T]>(
   path: T,
   ...[options]: Params extends void
-    ? [opts?: NavigateOptions]
-    : [opts: NavigateOptions & { params: Params }]
+    ? // If Params is void (no parameters required):
+      [opts?: NavigateOptions]
+    : Params extends NonNullable<unknown>
+      ? // If Params is any non-nullable type (includes objects and primitives):
+        [opts: NavigateOptions & { params: Params }]
+      : // For any other case (type is any):
+        [opts?: NavigateOptions & { params?: Params }]
 ) => action('rise-tools/kit-react-navigation/navigate', { path, options })
 
 export const goBack = () => action('rise-tools/kit-react-navigation/goBack')


### PR DESCRIPTION
This PR builds on top of work by @arpitBhalla with a few modifications to prepare the code for upcoming screen options (pending PR #158).

Instead of specifying type of `path` via `keyof typeof path`, it adds support for future type checking of screen params.

The following are type-checked:
```ts
navigate('form')
navigate('home', { params: { userId: 5 }})
```
for the following
```
interface Navigate {
  screens: {
      form: void
      home: { userId: 5 }
  }
}
```

In the future, we will automatically infer the type of params, as long as you passed in lookup type model (that takes params). 

If params are defined, options (second argument to navigate) are required, otherwise optional. Aside from `options.params`, you can also specify `screen` settings (will be implemented in a follow-up via #158). 
