### PR TITLE
readme: added build step before running the playground/demo server.

### DIFF
--- a/docs/docs/contributors.md
+++ b/docs/docs/contributors.md
@@ -20,14 +20,6 @@ cd rise-tools
 npm install
 ```
 
-## Generate Build
-
-After installing the dependencies, you need to generate the build for the project if you want to run the playground or the demo server:
-
-```sh
-npm run build
-```
-
 ### Run Tests
 
 `npm run test`
@@ -47,7 +39,9 @@ For Android: `npm run android`
 
 ### Run Demo Server
 
-First `cd example/demo`
+First, make sure you are in root folder of the project and run `npm run watch` to start the build watcher to view your changes live.
+
+then `cd example/demo`
 
 `npm run dev`
 

--- a/docs/docs/contributors.md
+++ b/docs/docs/contributors.md
@@ -20,6 +20,14 @@ cd rise-tools
 npm install
 ```
 
+## Generate Build
+
+After installing the dependencies, you need to generate the build for the project if you want to run the playground or the demo server:
+
+```sh
+npm run build
+```
+
 ### Run Tests
 
 `npm run test`


### PR DESCRIPTION
Hey,
Noticed the demo server or the playground requires the builds for the packages. Adding the build command info to the Contributor doc's page. Starting small with this change and looking forward to working on bigger PRs later 😄. let me know if I need to change anything like the position or styling of the info.