### PR TITLE
feat: infer lookup path for nested models and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ yarn-error.log
 
 # Lefthook
 lefthook.yml
+
+# Vitest
+**/*.vitest-temp.json

--- a/packages/server/src/__tests__/types.test-d.ts
+++ b/packages/server/src/__tests__/types.test-d.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+import { lookup } from '../model-lookup.js'
+import { view } from '../model-view.js'
+import type { InferModel } from '../types.js'
+
+describe('types', () => {
+  test('infer navigation types from models', () => {
+    const models = {
+      foo: () => null,
+      bar: view(() => null),
+    }
+    expectTypeOf<InferModel<typeof models>>().toMatchTypeOf<'foo' | 'bar'>()
+  })
+  test('infer navigation types from lookup models', () => {
+    const models = {
+      plain: lookup(() => view(() => null)),
+      nested: lookup(() => lookup(() => view(() => null))),
+    }
+    expectTypeOf<InferModel<typeof models>>().toMatchTypeOf<
+      `plain/${string}` | `nested/${string}/${string}`
+    >()
+  })
+})

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -34,26 +34,19 @@ export type AnyModels =
   | ValueModel<any>
   | LookupModel<any>
 
-type LookupModelPathOf<M, Prefix extends string = ''> =
-  M extends ValueModel<any>
-    ? `${Prefix}/${string}`
-    : M extends LookupModel<infer LM>
-      ? LookupModelPathOf<LM, `${Prefix}`>
-      : M extends object
-        ? InferModel<M, `${Prefix}/${string}/`>
-        : never
+export type LookupModelPathOf<M, Prefix extends string = ''> =
+  M extends LookupModel<infer NestedModel>
+    ? LookupModelPathOf<NestedModel, `${Prefix}/${string}`>
+    : Prefix
 
 type ExcludeSymbol<K> = K extends symbol ? never : K
 
-export type InferModel<T, Prefix extends string = ''> = T extends object
+export type InferModel<T> = T extends object
   ? {
       [ModelKey in keyof T]: T[ModelKey] extends ValueModel<any>
-        ? `${Prefix}${ExcludeSymbol<ModelKey>}`
-        : T[ModelKey] extends LookupModel<infer M>
-          ? LookupModelPathOf<M, `${Prefix}${ExcludeSymbol<ModelKey>}`>
-          : T[ModelKey] extends object
-            ? InferModel<T[ModelKey], `${Prefix}${ExcludeSymbol<ModelKey>}/`>
-            : never
+        ? `${ExcludeSymbol<ModelKey>}`
+        : T[ModelKey] extends LookupModel<any>
+          ? LookupModelPathOf<T[ModelKey], `${ExcludeSymbol<ModelKey>}`>
+          : never
     }[keyof T]
   : never
-

--- a/test/config.mjs
+++ b/test/config.mjs
@@ -16,6 +16,9 @@ export const node = defineProject({
   test: {
     environment: 'node',
     include: ['**/src/**/*.test.*'],
+    typecheck: {
+      enabled: true,
+    },
   },
   esbuild: {
     jsxDev: false,

--- a/test/config.mjs
+++ b/test/config.mjs
@@ -17,6 +17,7 @@ export const node = defineProject({
     environment: 'node',
     include: ['**/src/**/*.test.*'],
     typecheck: {
+      ignoreSourceErrors: true,
       enabled: true,
     },
   },


### PR DESCRIPTION
- Added tests for types (OMG, I love `vitest` so much!)
- Added support for nested/nested lookup models (wasn't working for some reason)
- Removed support for "objects" of models (this is currently not supported, we can always add it back)

CC: @arpitBhalla 