### PR TITLE
feat: fallback UI for the tunnel in the CLI 

### DIFF
--- a/example/demo/package.json
+++ b/example/demo/package.json
@@ -19,6 +19,7 @@
     "start": "tsx ./src"
   },
   "dependencies": {
+    "@rise-tools/cli": "0.5.0",
     "@rise-tools/react": "0.5.0",
     "@rise-tools/server": "0.5.0",
     "@rise-tools/kitchen-sink": "0.5.0",

--- a/example/demo/package.json
+++ b/example/demo/package.json
@@ -14,19 +14,20 @@
   },
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "scripts": {
-    "dev": "tsx watch ./src",
+    "dev": "cross-env NODE_ENV=development tsx watch ./src",
     "dev-simple-demo": "tsx watch ./src/simple-demo.tsx",
     "start": "tsx ./src"
   },
   "dependencies": {
     "@rise-tools/cli": "0.5.0",
-    "@rise-tools/react": "0.5.0",
-    "@rise-tools/server": "0.5.0",
+    "@rise-tools/kit-react-navigation": "0.5.0",
     "@rise-tools/kitchen-sink": "0.5.0",
-    "@rise-tools/kit-react-navigation": "0.5.0"
+    "@rise-tools/react": "0.5.0",
+    "@rise-tools/server": "0.5.0"
   },
   "devDependencies": {
     "@rise-tools/preset-typescript": "0.5.0",
+    "cross-env": "^7.0.3",
     "tsx": "^4.11.0",
     "typescript": "^5.1.3"
   }

--- a/example/demo/src/index.ts
+++ b/example/demo/src/index.ts
@@ -1,3 +1,4 @@
+import { setupRiseTools } from '@rise-tools/cli'
 import { createWSServer, InferModel } from '@rise-tools/server'
 
 import { models as delivery } from './delivery/ui'
@@ -9,6 +10,10 @@ const models = { ...inventory, ...controls, ...delivery }
 const port = Number(process.env.PORT || '3005')
 
 createWSServer(models, port)
+
+if (process.env.NODE_ENV === 'development') {
+  setupRiseTools({ protocol: 'ws', port, tunnel: true })
+}
 
 import '@rise-tools/kit-react-navigation/server'
 

--- a/example/demo/src/index.ts
+++ b/example/demo/src/index.ts
@@ -9,10 +9,10 @@ const models = { ...inventory, ...controls, ...delivery }
 
 const port = Number(process.env.PORT || '3005')
 
-createWSServer(models, port)
+const server = createWSServer(models, port)
 
 if (process.env.NODE_ENV === 'development') {
-  setupRiseTools({ protocol: 'ws', port, tunnel: true })
+  setupRiseTools({ server, tunnel: true })
 }
 
 import '@rise-tools/kit-react-navigation/server'

--- a/example/demo/src/index.ts
+++ b/example/demo/src/index.ts
@@ -12,7 +12,7 @@ const port = Number(process.env.PORT || '3005')
 const server = createWSServer(models, port)
 
 if (process.env.NODE_ENV === 'development') {
-  setupRiseTools({ server, tunnel: true })
+  setupRiseTools({ server })
 }
 
 import '@rise-tools/kit-react-navigation/server'

--- a/example/demo/tsconfig.json
+++ b/example/demo/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"extends": "@rise-tools/preset-typescript",
 	"references": [{
+    "path": "../../packages/cli"
+  }, {
     "path": "../../packages/kitchen-sink"
   }, {
     "path": "../../packages/react"

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
       "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@rise-tools/cli": "0.5.0",
         "@rise-tools/kit-react-navigation": "0.5.0",
         "@rise-tools/kitchen-sink": "0.5.0",
         "@rise-tools/react": "0.5.0",
@@ -37838,16 +37839,13 @@
       "dependencies": {
         "@fastify/websocket": "^10.0.1",
         "@rise-tools/cli": "0.5.0",
-        "dedent": "^1.5.3",
         "fastify": "^4.27.0",
         "ws": "^8.16.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@types/dedent": "^0.7.2",
         "@types/node": "^18.19.41",
-        "@types/ws": "^8.5.10",
-        "metro-react-native-babel-preset": "^0.77.0"
+        "@types/ws": "^8.5.10"
       }
     },
     "packages/server/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37497,6 +37497,7 @@
         "zx": "^8.1.4"
       },
       "devDependencies": {
+        "@rise-tools/server": "0.5.0",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/uuid": "^9.0.1"
       }
@@ -37838,7 +37839,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/websocket": "^10.0.1",
-        "@rise-tools/cli": "0.5.0",
         "fastify": "^4.27.0",
         "ws": "^8.16.0",
         "zod": "^3.22.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
       },
       "devDependencies": {
         "@rise-tools/preset-typescript": "0.5.0",
+        "cross-env": "^7.0.3",
         "tsx": "^4.11.0",
         "typescript": "^5.1.3"
       }
@@ -16248,6 +16249,24 @@
     "node_modules/create-rise": {
       "resolved": "packages/create-rise",
       "link": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "zx": "^8.1.4"
   },
   "devDependencies": {
+    "@rise-tools/server": "0.5.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/uuid": "^9.0.1"
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,3 @@
 export * from './theme'
 export * from './utils'
+export * from './welcome'

--- a/packages/cli/src/theme.ts
+++ b/packages/cli/src/theme.ts
@@ -1,6 +1,6 @@
 import makeGradient from 'gradient-string'
-// @ts-ignore
-import { chalk } from 'zx'
+
+import { chalk } from './zx'
 
 const hexColors = {
   highlight: '#FD48C1',
@@ -29,5 +29,4 @@ export const prompt = {
   },
 }
 
-// @ts-ignore
-export { spinner } from 'zx'
+export { spinner } from './zx'

--- a/packages/cli/src/theme.ts
+++ b/packages/cli/src/theme.ts
@@ -28,3 +28,6 @@ export const prompt = {
     error,
   },
 }
+
+// @ts-ignore
+export { spinner } from 'zx'

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -80,14 +80,11 @@ export async function startTunnel(port: number) {
   )
 
   const timeoutPromise = setTimeout(5000).then(() => {
-    throw new Error(
-      'Timeout: Did not establish succesful connection with Rise Proxy. Please try again.'
-    )
+    throw new Error('timeout')
   })
 
   const sessionPromise = new Promise<string>((resolve) => {
     session.stdout.on('data', (data: Buffer) => {
-      console.log(data.toString())
       const match = data.toString().match(/(?:http:\/\/)([^\s]+)/)
       if (match) {
         resolve(match[1]!)

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -94,13 +94,3 @@ export async function startTunnel(port: number) {
 
   return Promise.race([sessionPromise, timeoutPromise])
 }
-
-export const safePromise = async <T>(
-  promise: Promise<T>
-): Promise<[T | undefined, Error | undefined]> => {
-  try {
-    return [await promise, undefined]
-  } catch (error) {
-    return [undefined, error instanceof Error ? error : new Error('An unknown error occurred')]
-  }
-}

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -97,3 +97,13 @@ export async function startTunnel(port: number) {
 
   return Promise.race([sessionPromise, timeoutPromise])
 }
+
+export const safePromise = async <T>(
+  promise: Promise<T>
+): Promise<[T | undefined, Error | undefined]> => {
+  try {
+    return [await promise, undefined]
+  } catch (error) {
+    return [undefined, error instanceof Error ? error : new Error('An unknown error occurred')]
+  }
+}

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -7,8 +7,8 @@ import findUp from 'find-up'
 import internalIp from 'internal-ip'
 import qr from 'qrcode-terminal'
 import * as uuid from 'uuid'
-// @ts-ignore
-import { fs } from 'zx'
+
+import { fs } from './zx'
 
 export async function getHost() {
   return internalIp.v4()

--- a/packages/cli/src/welcome.ts
+++ b/packages/cli/src/welcome.ts
@@ -13,7 +13,26 @@ import {
 import type { Server } from '@rise-tools/server'
 import dedent from 'dedent'
 
-export async function setupRiseTools({ server, tunnel }: { server: Server; tunnel?: boolean }) {
+import { minimist } from './zx'
+
+type Options = {
+  tunnel: boolean
+}
+
+const opts = minimist<Options>(process.argv.slice(2), {
+  boolean: ['tunnel'],
+  default: {
+    tunnel: false,
+  },
+})
+
+export async function setupRiseTools({
+  server,
+  tunnel = opts.tunnel,
+}: {
+  server: Server
+  tunnel?: boolean
+}) {
   const host = (await getHost()) || 'localhost'
 
   const localUrl = `${server.protocol}://${host}:${server.port}`

--- a/packages/cli/src/welcome.ts
+++ b/packages/cli/src/welcome.ts
@@ -10,20 +10,13 @@ import {
   spinner,
   startTunnel,
 } from '@rise-tools/cli'
+import type { Server } from '@rise-tools/server'
 import dedent from 'dedent'
 
-export async function setupRiseTools({
-  protocol,
-  port,
-  tunnel,
-}: {
-  protocol: string
-  port: number
-  tunnel?: boolean
-}) {
+export async function setupRiseTools({ server, tunnel }: { server: Server; tunnel?: boolean }) {
   const host = (await getHost()) || 'localhost'
 
-  const localUrl = `${protocol}://${host}:${port}`
+  const localUrl = `${server.protocol}://${host}:${server.port}`
 
   clearTerminal()
 
@@ -33,7 +26,7 @@ export async function setupRiseTools({
   let deepLinkUrl = localUrl
   if (tunnel) {
     try {
-      const tunnelUrl = await spinner('Starting the tunnel...', () => startTunnel(port))
+      const tunnelUrl = await spinner('Starting the tunnel...', () => startTunnel(server.port))
       console.log(`Access anywhere on ${highlight(tunnelUrl)}`)
 
       deepLinkUrl = tunnelUrl

--- a/packages/cli/src/welcome.ts
+++ b/packages/cli/src/welcome.ts
@@ -12,7 +12,15 @@ import {
 } from '@rise-tools/cli'
 import dedent from 'dedent'
 
-export async function printInstructions({ protocol, port }: { protocol: string; port: number }) {
+export async function setupRiseTools({
+  protocol,
+  port,
+  tunnel,
+}: {
+  protocol: string
+  port: number
+  tunnel?: boolean
+}) {
   const host = (await getHost()) || 'localhost'
 
   const localUrl = `${protocol}://${host}:${port}`
@@ -23,17 +31,19 @@ export async function printInstructions({ protocol, port }: { protocol: string; 
   console.log(`Listening on ${highlight(localUrl)}`)
 
   let deepLinkUrl = localUrl
-  try {
-    const tunnelUrl = await spinner('Starting the tunnel...', () => startTunnel(port))
-    console.log(`Access anywhere on ${highlight(tunnelUrl)}`)
+  if (tunnel) {
+    try {
+      const tunnelUrl = await spinner('Starting the tunnel...', () => startTunnel(port))
+      console.log(`Access anywhere on ${highlight(tunnelUrl)}`)
 
-    deepLinkUrl = tunnelUrl
-  } catch (e) {
-    console.log(
-      debug(
-        'Failed to connect to Rise Proxy. You can access the server only on your local network.'
+      deepLinkUrl = tunnelUrl
+    } catch (e) {
+      console.log(
+        debug(
+          'Failed to connect to Rise Proxy. You can access the server only on your local network.'
+        )
       )
-    )
+    }
   }
 
   console.log('')

--- a/packages/cli/src/zx.ts
+++ b/packages/cli/src/zx.ts
@@ -1,0 +1,2 @@
+// @ts-ignore - https://github.com/google/zx/issues/871
+export * from 'zx'

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib"
-  }
+  },
+  "references": [
+    {
+      "path": "../server"
+    }
+  ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "dependencies": {
     "@fastify/websocket": "^10.0.1",
-    "@rise-tools/cli": "0.5.0",
     "fastify": "^4.27.0",
     "ws": "^8.16.0",
     "zod": "^3.22.4"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,15 +28,12 @@
   "dependencies": {
     "@fastify/websocket": "^10.0.1",
     "@rise-tools/cli": "0.5.0",
-    "dedent": "^1.5.3",
     "fastify": "^4.27.0",
     "ws": "^8.16.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/dedent": "^0.7.2",
     "@types/node": "^18.19.41",
-    "@types/ws": "^8.5.10",
-    "metro-react-native-babel-preset": "^0.77.0"
+    "@types/ws": "^8.5.10"
   }
 }

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -1,9 +1,9 @@
 import Fastify from 'fastify'
 
 import { findModel } from './model-utils'
-import { AnyModels } from './types'
+import { AnyModels, Server } from './types'
 
-export async function createHTTPServer(models: AnyModels, port: number) {
+export async function createHTTPServer(models: AnyModels, port: number): Promise<Server> {
   const server = Fastify({
     // logger: true,
   })
@@ -15,6 +15,8 @@ export async function createHTTPServer(models: AnyModels, port: number) {
   })
   await server.listen({ port })
   return {
+    port,
+    protocol: 'http',
     close() {
       server.close()
     },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -14,8 +14,6 @@ export interface CreateServerOptions {
   ws?: boolean
 }
 
-// tbd: what should we do for `createServer` that ultimately supports both HTTP and WS,
-// in terms of generating connection string?
 export async function createServer(models: AnyModels, port: number) {
   const server = Fastify()
   server.register(fastifyWebsocket)

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -50,3 +50,9 @@ export type InferModel<T> = T extends object
           : never
     }[keyof T]
   : never
+
+export type Server = {
+  protocol: 'ws' | 'http'
+  port: number
+  close: () => void
+}

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -1,35 +1,40 @@
 import {
   clearTerminal,
+  debug,
   generateQRCode,
   getConnectionURL,
   getHost,
   highlight,
   link,
   logo,
+  safePromise,
   startTunnel,
 } from '@rise-tools/cli'
 import dedent from 'dedent'
 
 export async function printInstructions({ protocol, port }: { protocol: string; port: number }) {
   const host = (await getHost()) || 'localhost'
+
+  const [tunnelHost, tunnelError] = await safePromise(startTunnel(port))
+
   const localUrl = `${protocol}://${host}:${port}`
 
-  const remoteUrl = `${protocol}://${await startTunnel(port)}`
+  const remoteUrl = `${protocol}://${tunnelHost}`
 
   clearTerminal()
 
   console.log(logo())
 
-  const deepLink = await getConnectionURL(remoteUrl)
+  const deepLink = await getConnectionURL(remoteUrl ?? localUrl)
 
   console.log(dedent`
     Listening on ${highlight(localUrl)}
-    Access anywhere on ${highlight(remoteUrl)}  
+    Access anywhere on ${tunnelError ? debug('Tunnel available. ' + tunnelError.message) : highlight(remoteUrl)}
 
     To preview your app in the Rise Playground, scan the QR code:
     ${await generateQRCode(deepLink)}
 
     Or open the following link on your device:
-    ${link(deepLink)}  
+    ${link(deepLink)}
   `)
 }

--- a/packages/server/src/ws-server.ts
+++ b/packages/server/src/ws-server.ts
@@ -1,7 +1,6 @@
 import { WebSocketServer } from 'ws'
 
 import { AnyModels } from './types'
-import { printInstructions } from './utils'
 import { connectWebSocket, createWSServerContext } from './ws-connection'
 
 export function createWSServer(models: AnyModels, port: number) {
@@ -11,8 +10,6 @@ export function createWSServer(models: AnyModels, port: number) {
   wss.on('connection', (ws) => {
     connectWebSocket(context, ws)
   })
-
-  printInstructions({ protocol: 'ws', port })
 
   return {
     close() {

--- a/packages/server/src/ws-server.ts
+++ b/packages/server/src/ws-server.ts
@@ -1,9 +1,9 @@
 import { WebSocketServer } from 'ws'
 
-import { AnyModels } from './types'
+import { AnyModels, Server } from './types'
 import { connectWebSocket, createWSServerContext } from './ws-connection'
 
-export function createWSServer(models: AnyModels, port: number) {
+export function createWSServer(models: AnyModels, port: number): Server {
   const wss = new WebSocketServer({ port })
   const context = createWSServerContext(models)
 
@@ -12,6 +12,8 @@ export function createWSServer(models: AnyModels, port: number) {
   })
 
   return {
+    port,
+    protocol: 'ws',
     close() {
       wss.close()
     },

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -7,9 +7,6 @@
   "references": [
     {
       "path": "../react"
-    },
-    {
-      "path": "../cli"
     }
   ]
 }

--- a/templates/blank-playground/package.json
+++ b/templates/blank-playground/package.json
@@ -27,9 +27,10 @@
   "homepage": "https://github.com/rise-tools/rise-tools#readme",
   "scripts": {
     "start": "tsx src/server.ts",
-    "dev": "tsx watch src/server.ts"
+    "dev": "cross-env NODE_ENV=development tsx watch src/server.ts"
   },
   "dependencies": {
+    "@rise-tools/cli": "0.5.0",
     "@rise-tools/kit-react-navigation": "0.5.0",
     "@rise-tools/kitchen-sink": "0.5.0",
     "@rise-tools/server": "0.5.0"
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@rise-tools/preset-typescript": "0.5.0",
     "@types/react": "^18.0.27",
+    "cross-env": "^7.0.3",
     "tsx": "^4.11.0",
     "typescript": "^5.1.3"
   },

--- a/templates/blank-playground/src/server.ts
+++ b/templates/blank-playground/src/server.ts
@@ -1,7 +1,12 @@
+import { setupRiseTools } from '@rise-tools/cli'
 import { createWSServer } from '@rise-tools/server'
 
 import { models } from './models'
 
 const port = Number(process.env.PORT || '3005')
 
-createWSServer(models, port)
+const server = createWSServer(models, port)
+
+if (process.env.NODE_ENV === 'development') {
+  setupRiseTools({ server })
+}


### PR DESCRIPTION
Here's the behavior:

While connecting:
<img width="321" alt="Screenshot 2024-07-21 at 20 05 27" src="https://github.com/user-attachments/assets/8aa2929c-2716-4e15-a517-42f5c66972d0">

Failed (maximum timeout: 5s)
<img width="648" alt="Screenshot 2024-07-21 at 20 07 08" src="https://github.com/user-attachments/assets/da760adc-c50f-4c66-90df-91a1a7d95e1b">

Connected:
<img width="542" alt="Screenshot 2024-07-21 at 21 52 09" src="https://github.com/user-attachments/assets/5bcfa979-2046-4293-bd6e-734dad7e70c8">

QR Code is displayed as always.

