### PR TITLE
feat: replace hardcoded list of examples with partial Rise screen

### DIFF
--- a/apps/mobile/src/back-button.tsx
+++ b/apps/mobile/src/back-button.tsx
@@ -4,7 +4,7 @@ import { X } from '@tamagui/lucide-icons'
 import { Platform } from 'react-native'
 import { Button, ButtonProps, Image, Separator } from 'tamagui'
 
-import { Connection, EXAMPLE_CONNECTION } from './connection'
+import { Connection, DEMO_CONNECTION } from './connection'
 import { Dropdown, DropdownItem } from './dropdown'
 import { RootStackParamList } from './screens'
 import type { RiseStackParamList } from './screens/connection'
@@ -54,7 +54,7 @@ export function BackButton({ connection }: { connection?: Connection }) {
       <DropdownItem onPress={() => navigation.navigate('qr-code')} Icon={Share}>
         Share Connection
       </DropdownItem>
-      {connection && connection.id !== EXAMPLE_CONNECTION.id && (
+      {connection && connection.id !== DEMO_CONNECTION.id && (
         <>
           <Separator />
           <DropdownItem

--- a/apps/mobile/src/back-button.tsx
+++ b/apps/mobile/src/back-button.tsx
@@ -50,12 +50,12 @@ export function BackButton({ connection }: { connection?: Connection }) {
       <DropdownItem onPress={() => navigation.goBack()} Icon={Home}>
         Go Home
       </DropdownItem>
-      <Separator />
-      <DropdownItem onPress={() => navigation.navigate('qr-code')} Icon={Share}>
-        Share Connection
-      </DropdownItem>
       {connection && connection.id !== DEMO_CONNECTION.id && (
         <>
+          <Separator />
+          <DropdownItem onPress={() => navigation.navigate('qr-code')} Icon={Share}>
+            Share Connection
+          </DropdownItem>
           <Separator />
           <DropdownItem
             onPress={() => navigation.navigate('edit-connection', { id: connection.id })}

--- a/apps/mobile/src/back-button.tsx
+++ b/apps/mobile/src/back-button.tsx
@@ -4,7 +4,7 @@ import { X } from '@tamagui/lucide-icons'
 import { Platform } from 'react-native'
 import { Button, ButtonProps, Image, Separator } from 'tamagui'
 
-import { BUILTIN_CONNECTIONS, Connection } from './connection'
+import { Connection, EXAMPLE_CONNECTION } from './connection'
 import { Dropdown, DropdownItem } from './dropdown'
 import { RootStackParamList } from './screens'
 import type { RiseStackParamList } from './screens/connection'
@@ -54,7 +54,7 @@ export function BackButton({ connection }: { connection?: Connection }) {
       <DropdownItem onPress={() => navigation.navigate('qr-code')} Icon={Share}>
         Share Connection
       </DropdownItem>
-      {connection && Object.keys(BUILTIN_CONNECTIONS).includes(connection.id) === false && (
+      {connection && connection.id !== EXAMPLE_CONNECTION.id && (
         <>
           <Separator />
           <DropdownItem

--- a/apps/mobile/src/back-button.tsx
+++ b/apps/mobile/src/back-button.tsx
@@ -39,32 +39,36 @@ export function HeaderButton(props: ButtonProps) {
 export function BackButton({ connection }: { connection?: Connection }) {
   const navigation = useNavigation<NavigationProp<RiseStackParamList & RootStackParamList>>()
 
+  if (connection && connection.id !== DEMO_CONNECTION.id) {
+    return (
+      <Dropdown
+        trigger={
+          <HeaderButton>
+            <Image src={require('../assets/RiseMainIcon.png')} aspectRatio={1} height={25} />
+          </HeaderButton>
+        }
+      >
+        <DropdownItem onPress={() => navigation.goBack()} Icon={Home}>
+          Go Home
+        </DropdownItem>
+        <Separator />
+        <DropdownItem onPress={() => navigation.navigate('qr-code')} Icon={Share}>
+          Share Connection
+        </DropdownItem>
+        <Separator />
+        <DropdownItem
+          onPress={() => navigation.navigate('edit-connection', { id: connection.id })}
+          Icon={Pencil}
+        >
+          Edit Connection
+        </DropdownItem>
+      </Dropdown>
+    )
+  }
+
   return (
-    <Dropdown
-      trigger={
-        <HeaderButton>
-          <Image src={require('../assets/RiseMainIcon.png')} aspectRatio={1} height={25} />
-        </HeaderButton>
-      }
-    >
-      <DropdownItem onPress={() => navigation.goBack()} Icon={Home}>
-        Go Home
-      </DropdownItem>
-      {connection && connection.id !== DEMO_CONNECTION.id && (
-        <>
-          <Separator />
-          <DropdownItem onPress={() => navigation.navigate('qr-code')} Icon={Share}>
-            Share Connection
-          </DropdownItem>
-          <Separator />
-          <DropdownItem
-            onPress={() => navigation.navigate('edit-connection', { id: connection.id })}
-            Icon={Pencil}
-          >
-            Edit Connection
-          </DropdownItem>
-        </>
-      )}
-    </Dropdown>
+    <HeaderButton onPress={() => navigation.goBack()}>
+      <Image src={require('../assets/RiseMainIcon.png')} aspectRatio={1} height={25} />
+    </HeaderButton>
   )
 }

--- a/apps/mobile/src/connection.tsx
+++ b/apps/mobile/src/connection.tsx
@@ -23,8 +23,8 @@ export function useConnection(id?: string) {
   if (!id) {
     return
   }
-  if (id === EXAMPLE_CONNECTION.id) {
-    return EXAMPLE_CONNECTION
+  if (id === DEMO_CONNECTION.id) {
+    return DEMO_CONNECTION
   }
   return state.find((connection) => connection.id === id)
 }
@@ -49,7 +49,7 @@ export function updateConnection(id: string, connection: ConnectionPayload) {
   })
 }
 
-export const EXAMPLE_CONNECTION: Connection = {
+export const DEMO_CONNECTION: Connection = {
   id: 'example',
   label: '🏭 Example',
   host: DEMO_WS_URL,

--- a/apps/mobile/src/connection.tsx
+++ b/apps/mobile/src/connection.tsx
@@ -50,22 +50,28 @@ export function updateConnection(id: string, connection: ConnectionPayload) {
 }
 
 export const BUILTIN_CONNECTIONS: Record<string, Connection> = {
-  inventory: {
-    id: 'inventory',
-    label: '🏭 Car Parts Inventory',
+  example: {
+    id: 'example',
+    label: '🏭 Example',
     host: DEMO_WS_URL,
-    path: 'inventory',
+    path: '',
   },
-  ui: {
-    id: 'ui',
-    label: '🎨 UI Controls',
-    host: DEMO_WS_URL,
-    path: 'controls',
-  },
-  delivery: {
-    id: 'delivery',
-    label: '🚚 Super Delivery',
-    host: DEMO_WS_URL,
-    path: 'delivery',
-  },
+  // inventory: {
+  //   id: 'inventory',
+  //   label: '🏭 Car Parts Inventory',
+  //   host: DEMO_WS_URL,
+  //   path: 'inventory',
+  // },
+  // ui: {
+  //   id: 'ui',
+  //   label: '🎨 UI Controls',
+  //   host: DEMO_WS_URL,
+  //   path: 'controls',
+  // },
+  // delivery: {
+  //   id: 'delivery',
+  //   label: '🚚 Super Delivery',
+  //   host: process.env.EXPO_PUBLIC_DEMO_WS_URL as string,
+  //   path: 'delivery',
+  // },
 }

--- a/apps/mobile/src/connection.tsx
+++ b/apps/mobile/src/connection.tsx
@@ -23,8 +23,8 @@ export function useConnection(id?: string) {
   if (!id) {
     return
   }
-  if (BUILTIN_CONNECTIONS[id]) {
-    return BUILTIN_CONNECTIONS[id]
+  if (id === EXAMPLE_CONNECTION.id) {
+    return EXAMPLE_CONNECTION
   }
   return state.find((connection) => connection.id === id)
 }
@@ -49,29 +49,9 @@ export function updateConnection(id: string, connection: ConnectionPayload) {
   })
 }
 
-export const BUILTIN_CONNECTIONS: Record<string, Connection> = {
-  example: {
-    id: 'example',
-    label: '🏭 Example',
-    host: DEMO_WS_URL,
-    path: '',
-  },
-  // inventory: {
-  //   id: 'inventory',
-  //   label: '🏭 Car Parts Inventory',
-  //   host: DEMO_WS_URL,
-  //   path: 'inventory',
-  // },
-  // ui: {
-  //   id: 'ui',
-  //   label: '🎨 UI Controls',
-  //   host: DEMO_WS_URL,
-  //   path: 'controls',
-  // },
-  // delivery: {
-  //   id: 'delivery',
-  //   label: '🚚 Super Delivery',
-  //   host: process.env.EXPO_PUBLIC_DEMO_WS_URL as string,
-  //   path: 'delivery',
-  // },
+export const EXAMPLE_CONNECTION: Connection = {
+  id: 'example',
+  label: '🏭 Example',
+  host: DEMO_WS_URL,
+  path: '',
 }

--- a/apps/mobile/src/connection.tsx
+++ b/apps/mobile/src/connection.tsx
@@ -51,7 +51,7 @@ export function updateConnection(id: string, connection: ConnectionPayload) {
 
 export const DEMO_CONNECTION: Connection = {
   id: 'example',
-  label: '🏭 Example',
+  label: 'Rise Example UI',
   host: DEMO_WS_URL,
   path: '',
 }

--- a/apps/mobile/src/screens/connection.tsx
+++ b/apps/mobile/src/screens/connection.tsx
@@ -60,7 +60,6 @@ export function ConnectionScreen({
         options={{
           headerLeft: () => <BackButton connection={connection} />,
           title: connection?.label || connection?.path,
-          // @ts-ignore
           ...(route.params.options || {}),
         }}
       >

--- a/apps/mobile/src/screens/connection.tsx
+++ b/apps/mobile/src/screens/connection.tsx
@@ -63,7 +63,7 @@ export function ConnectionScreen({
           ...(route.params.options || {}),
         }}
       >
-        {() => <RiseScreen connection={connection!} path={route.params.path || connection!.path} />}
+        {() => <RiseScreen connection={connection!} path={route.params.path} />}
       </Stack.Screen>
       <Stack.Screen
         name="rise"
@@ -96,11 +96,11 @@ export function ConnectionScreen({
 
 export function RiseScreen({
   connection,
-  path,
+  path = connection.path,
   actions = {},
 }: {
   connection: Connection
-  path: string
+  path?: string
   actions?: Record<string, any>
 }) {
   const modelSource = useModelSource(connection.id, connection.host)

--- a/apps/mobile/src/screens/connection.tsx
+++ b/apps/mobile/src/screens/connection.tsx
@@ -60,9 +60,11 @@ export function ConnectionScreen({
         options={{
           headerLeft: () => <BackButton connection={connection} />,
           title: connection?.label || connection?.path,
+          // @ts-ignore
+          ...(route.params.options || {}),
         }}
       >
-        {() => <RiseScreen connection={connection!} path={connection!.path || ''} />}
+        {() => <RiseScreen connection={connection!} path={route.params.path || connection!.path} />}
       </Stack.Screen>
       <Stack.Screen
         name="rise"
@@ -93,17 +95,30 @@ export function ConnectionScreen({
   )
 }
 
-function RiseScreen({ connection, path }: { connection: Connection; path: string }) {
+export function RiseScreen({
+  connection,
+  path,
+  actions = {},
+}: {
+  connection: Connection
+  path: string
+  actions?: Record<string, any>
+}) {
   const modelSource = useModelSource(connection.id, connection.host)
-  const actions = {
-    ...useReactNavigationActions({ routeName: 'rise' }),
-    ...useToastActions(),
-    ...useHapticsActions(),
-    ...useLinkingActions(),
-  }
   return (
     <DataBoundary modelSource={modelSource} path={path}>
-      <Rise components={components} modelSource={modelSource} path={path} actions={actions} />
+      <Rise
+        components={components}
+        modelSource={modelSource}
+        path={path}
+        actions={{
+          ...useReactNavigationActions({ routeName: 'rise' }),
+          ...useToastActions(),
+          ...useHapticsActions(),
+          ...useLinkingActions(),
+          ...actions,
+        }}
+      />
     </DataBoundary>
   )
 }

--- a/apps/mobile/src/screens/home.tsx
+++ b/apps/mobile/src/screens/home.tsx
@@ -15,7 +15,7 @@ import { ScrollView } from 'react-native'
 import { Button, Image, Separator, Text, View, XStack, YGroup, YStack } from 'tamagui'
 
 import { PRIVACY_POLICY_URL } from '../config'
-import { Connection, connections, EXAMPLE_CONNECTION } from '../connection'
+import { Connection, connections, DEMO_CONNECTION } from '../connection'
 import { Dropdown, DropdownItem } from '../dropdown'
 import { RootStackParamList } from '.'
 import { RiseScreen } from './connection'
@@ -32,7 +32,7 @@ export function HomeScreen() {
             {state.map((connection) => (
               <ConnectionItem key={connection.id} connection={connection} />
             ))}
-            {state.length > 0 && <ConnectionItem connection={EXAMPLE_CONNECTION} readonly />}
+            {state.length > 0 && <ConnectionItem connection={DEMO_CONNECTION} readonly />}
           </YGroup>
           <NewConnectionButton />
         </YStack>
@@ -57,7 +57,7 @@ function Examples() {
     },
   } satisfies ReturnType<typeof useReactNavigationActions>
 
-  return <RiseScreen connection={EXAMPLE_CONNECTION} path="" actions={actions} />
+  return <RiseScreen connection={DEMO_CONNECTION} path="" actions={actions} />
 }
 
 function HeroImage() {

--- a/apps/mobile/src/screens/home.tsx
+++ b/apps/mobile/src/screens/home.tsx
@@ -14,12 +14,30 @@ import { ScrollView } from 'react-native'
 import { Button, Image, Separator, Text, View, XStack, YGroup, YStack } from 'tamagui'
 
 import { PRIVACY_POLICY_URL } from '../config'
-import { BUILTIN_CONNECTIONS, Connection, connections } from '../connection'
+import { Connection, connections, useConnection } from '../connection'
 import { Dropdown, DropdownItem } from '../dropdown'
 import { RootStackParamList } from '.'
+import { RiseScreen } from './connection'
 
 export function HomeScreen() {
   const state = useStream(connections)
+  const connection = useConnection('example')
+
+  const navigation = useNavigation()
+
+  const actions = {
+    'rise-tools/kit-react-navigation/navigate': {
+      // @ts-ignore
+      action: ({ path, options }) => {
+        // @ts-ignore
+        navigation.navigate('connection', {
+          id: 'example',
+          path,
+          options,
+        })
+      },
+    },
+  }
 
   return (
     <ScrollView>
@@ -33,15 +51,8 @@ export function HomeScreen() {
           </YGroup>
           <NewConnectionButton />
         </YStack>
-        {state.length === 0 && (
-          <YStack gap="$2">
-            <Text textAlign="center">or try some of the examples below:</Text>
-            <YGroup separator={<Separator />}>
-              {Object.values(BUILTIN_CONNECTIONS).map((connection) => (
-                <ConnectionItem key={connection.id} connection={connection} readonly />
-              ))}
-            </YGroup>
-          </YStack>
+        {state.length === 0 && connection && (
+          <RiseScreen connection={connection} path="" actions={actions} />
         )}
       </YStack>
     </ScrollView>

--- a/apps/mobile/src/screens/home.tsx
+++ b/apps/mobile/src/screens/home.tsx
@@ -57,7 +57,7 @@ function Examples() {
     },
   } satisfies ReturnType<typeof useReactNavigationActions>
 
-  return <RiseScreen connection={DEMO_CONNECTION} path="" actions={actions} />
+  return <RiseScreen connection={DEMO_CONNECTION} actions={actions} />
 }
 
 function HeroImage() {

--- a/apps/mobile/src/screens/home.tsx
+++ b/apps/mobile/src/screens/home.tsx
@@ -49,7 +49,7 @@ function Examples() {
     'rise-tools/kit-react-navigation/navigate': {
       action: ({ path, options }) => {
         navigation.navigate('connection', {
-          id: 'example',
+          id: DEMO_CONNECTION.id,
           path,
           options,
         })

--- a/apps/mobile/src/screens/home.tsx
+++ b/apps/mobile/src/screens/home.tsx
@@ -1,5 +1,6 @@
-import { useNavigation } from '@react-navigation/native'
+import { NavigationProp, useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { useReactNavigationActions } from '@rise-tools/kit-react-navigation'
 import { useStream } from '@rise-tools/react'
 import {
   BookOpenText,
@@ -14,30 +15,13 @@ import { ScrollView } from 'react-native'
 import { Button, Image, Separator, Text, View, XStack, YGroup, YStack } from 'tamagui'
 
 import { PRIVACY_POLICY_URL } from '../config'
-import { Connection, connections, useConnection } from '../connection'
+import { Connection, connections, EXAMPLE_CONNECTION } from '../connection'
 import { Dropdown, DropdownItem } from '../dropdown'
 import { RootStackParamList } from '.'
 import { RiseScreen } from './connection'
 
 export function HomeScreen() {
   const state = useStream(connections)
-  const connection = useConnection('example')
-
-  const navigation = useNavigation()
-
-  const actions = {
-    'rise-tools/kit-react-navigation/navigate': {
-      // @ts-ignore
-      action: ({ path, options }) => {
-        // @ts-ignore
-        navigation.navigate('connection', {
-          id: 'example',
-          path,
-          options,
-        })
-      },
-    },
-  }
 
   return (
     <ScrollView>
@@ -48,15 +32,32 @@ export function HomeScreen() {
             {state.map((connection) => (
               <ConnectionItem key={connection.id} connection={connection} />
             ))}
+            {state.length > 0 && <ConnectionItem connection={EXAMPLE_CONNECTION} readonly />}
           </YGroup>
           <NewConnectionButton />
         </YStack>
-        {state.length === 0 && connection && (
-          <RiseScreen connection={connection} path="" actions={actions} />
-        )}
+        {state.length === 0 && <Examples />}
       </YStack>
     </ScrollView>
   )
+}
+
+function Examples() {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>()
+
+  const actions = {
+    'rise-tools/kit-react-navigation/navigate': {
+      action: ({ path, options }) => {
+        navigation.navigate('connection', {
+          id: 'example',
+          path,
+          options,
+        })
+      },
+    },
+  } satisfies ReturnType<typeof useReactNavigationActions>
+
+  return <RiseScreen connection={EXAMPLE_CONNECTION} path="" actions={actions} />
 }
 
 function HeroImage() {
@@ -87,13 +88,13 @@ function ConnectionItem({
               {connection.label}
             </Text>
           </View>
-          {!readonly && (
-            <Button
-              backgroundColor="transparent"
-              icon={Settings}
-              onPress={() => navigation.push('edit-connection', { id: connection.id })}
-            />
-          )}
+          <Button
+            backgroundColor="transparent"
+            icon={Settings}
+            onPress={() => navigation.push('edit-connection', { id: connection.id })}
+            disabled={readonly}
+            opacity={readonly ? 0 : 1}
+          />
         </XStack>
       </Button>
     </YGroup.Item>

--- a/apps/mobile/src/screens/index.tsx
+++ b/apps/mobile/src/screens/index.tsx
@@ -1,4 +1,7 @@
-import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationOptions,
+} from '@react-navigation/native-stack'
 import React from 'react'
 
 import { ConnectScreen } from './connect'
@@ -10,7 +13,7 @@ import { NewConnectionScreen } from './new-connection'
 export type RootStackParamList = {
   home: undefined
   connect: { connectInfo?: string }
-  connection: { id: string; path?: string }
+  connection: { id: string; path?: string; options?: NativeStackNavigationOptions }
   'edit-connection': { id: string }
   'new-connection': undefined
 }

--- a/apps/mobile/src/screens/index.tsx
+++ b/apps/mobile/src/screens/index.tsx
@@ -10,7 +10,7 @@ import { NewConnectionScreen } from './new-connection'
 export type RootStackParamList = {
   home: undefined
   connect: { connectInfo?: string }
-  connection: { id: string }
+  connection: { id: string; path?: string }
   'edit-connection': { id: string }
   'new-connection': undefined
 }


### PR DESCRIPTION
- Do not hardcode examples, instead, use default screen for our example and render it in a partial view
  - To do so, we need to slightly overwrite "navigate" action in that partial screen to properly navigate into Rise navigator
- Remove "Share" option for default example. We always render it. Also, it would not work, because there's special handling for "example" ID anyways
- That said, dropdown now has just one option for builtin connection - "Go back". Decided to make the Rise logo always go back for builtin connection (no dropdown). Saves one extra click.
- When you have custom connection, the "Example" will render as always, at the end.

Questions:
- How should the "Example" be named? Right now, it's just "Example".

Screenshots:
<img src="https://github.com/user-attachments/assets/46c5d1c2-91bb-40e0-a7f9-e4cce8c74ce4" width="300" />
<img src="https://github.com/user-attachments/assets/59b6e0e7-3baf-4a51-9561-44290c79d51b" width="300" />
<img src="https://github.com/user-attachments/assets/7696efaf-a18f-4188-b809-17089cb033f3" width="300" />
<img src="https://github.com/user-attachments/assets/00a8fd5f-b4fd-4222-b8e1-e96a028c4493" width="300" />


