### PR TITLE
feat(playground): added custom `Splash screen`

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -8,8 +8,6 @@
     "icon": "./assets/RiseIcon.png",
     "userInterfaceStyle": "automatic",
     "splash": {
-      "image": "./assets/RiseSplash.png",
-      "resizeMode": "contain",
       "backgroundColor": "#260162"
     },
     "updates": {

--- a/apps/mobile/src/index.tsx
+++ b/apps/mobile/src/index.tsx
@@ -9,6 +9,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 
 import { Screens } from './screens'
+import { SplashScreen } from './splash-screen'
 import { storage } from './storage'
 import { tamaguiConfig } from './tamagui/config'
 import { TamaguiProvider } from './tamagui/provider'
@@ -40,22 +41,24 @@ function App() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <TamaguiProvider config={tamaguiConfig}>
-          <NavigationContainer
-            linking={{
-              prefixes: [prefix],
-            }}
-            theme={{
-              ...theme,
-              colors: {
-                ...theme.colors,
-                primary: scheme === 'dark' ? '#FD5811' : '#E74500',
-              },
-            }}
-            initialState={initialState ? JSON.parse(initialState) : undefined}
-            onStateChange={(state) => storage.set('react-navigation', JSON.stringify(state))}
-          >
-            <Screens />
-          </NavigationContainer>
+          <SplashScreen loaded={loaded}>
+            <NavigationContainer
+              linking={{
+                prefixes: [prefix],
+              }}
+              theme={{
+                ...theme,
+                colors: {
+                  ...theme.colors,
+                  primary: scheme === 'dark' ? '#FD5811' : '#E74500',
+                },
+              }}
+              initialState={initialState ? JSON.parse(initialState) : undefined}
+              onStateChange={(state) => storage.set('react-navigation', JSON.stringify(state))}
+            >
+              <Screens />
+            </NavigationContainer>
+          </SplashScreen>
         </TamaguiProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/src/splash-screen.tsx
+++ b/apps/mobile/src/splash-screen.tsx
@@ -11,12 +11,14 @@ import Animated, {
 Splash.preventAutoHideAsync()
 
 const AnimatedImage = Animated.createAnimatedComponent(Image)
+const AnimatedView = Animated.createAnimatedComponent(View)
 
 export function SplashScreen({ children, loaded }: { children: React.ReactNode; loaded: boolean }) {
   const [isAppReady, setIsAppReady] = useState(false)
   const opacity = useSharedValue(0)
+  const bgOpacity = useSharedValue(1)
   const scale = useSharedValue(0.5)
-  const rotation = useSharedValue(0)
+  const rotation = useSharedValue(315)
 
   useEffect(() => {
     startAnimation()
@@ -24,15 +26,17 @@ export function SplashScreen({ children, loaded }: { children: React.ReactNode; 
 
   const startAnimation = async () => {
     await Splash.hideAsync()
-    opacity.value = withTiming(1, { duration: 2000 })
-    rotation.value = withTiming(360, { duration: 2000 })
-    scale.value = withTiming(1, { duration: 2000 }, () => {
-      runOnJS(onAnimationComplete)()
+    opacity.value = withTiming(1, { duration: 500 })
+    rotation.value = withTiming(360, { duration: 500 })
+    scale.value = withTiming(1, { duration: 500 }, () => {
+      bgOpacity.value = withTiming(0, { duration: 500 }, () => {
+        runOnJS(onAnimationComplete)()
+      })
     })
   }
 
   const onAnimationComplete = async () => {
-    setTimeout(() => setIsAppReady(true), 1000)
+    setTimeout(() => setIsAppReady(true), 500)
   }
 
   const animatedStyles = useAnimatedStyle(() => {
@@ -41,25 +45,31 @@ export function SplashScreen({ children, loaded }: { children: React.ReactNode; 
       transform: [{ scale: scale.value }, { rotate: rotation.value + 'deg' }],
     }
   })
+  const animatedBgStyles = useAnimatedStyle(() => {
+    return {
+      opacity: bgOpacity.value,
+    }
+  })
 
-  if (!isAppReady || !loaded) {
-    return (
-      <View style={styles.container}>
-        <AnimatedImage
-          source={require('../assets/RiseMainIcon.png')}
-          style={[styles.logo, animatedStyles]}
-          resizeMode="contain"
-        />
-      </View>
-    )
-  }
-
-  return <>{children}</>
+  return (
+    <View style={{ flex: 1 }}>
+      {children}
+      {(!isAppReady || !loaded) && (
+        <AnimatedView style={[styles.container, animatedBgStyles]}>
+          <AnimatedImage
+            source={require('../assets/RiseMainIcon.png')}
+            style={[styles.logo, animatedStyles]}
+            resizeMode="contain"
+          />
+        </AnimatedView>
+      )}
+    </View>
+  )
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    ...StyleSheet.absoluteFillObject,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: '#260162',

--- a/apps/mobile/src/splash-screen.tsx
+++ b/apps/mobile/src/splash-screen.tsx
@@ -15,28 +15,39 @@ const AnimatedView = Animated.createAnimatedComponent(View)
 
 export function SplashScreen({ children, loaded }: { children: React.ReactNode; loaded: boolean }) {
   const [isAppReady, setIsAppReady] = useState(false)
+  const [isInitialAnimationDone, setIsInitialAnimationDone] = useState(false)
   const opacity = useSharedValue(0)
   const bgOpacity = useSharedValue(1)
   const scale = useSharedValue(0.5)
-  const rotation = useSharedValue(315)
+  const rotation = useSharedValue(270)
 
   useEffect(() => {
-    startAnimation()
+    startInitialAnimation()
   }, [])
 
-  const startAnimation = async () => {
+  useEffect(() => {
+    if (isInitialAnimationDone && loaded) {
+      startFinalAnimation()
+    }
+  }, [isInitialAnimationDone, loaded])
+
+  const startInitialAnimation = async () => {
     await Splash.hideAsync()
-    opacity.value = withTiming(1, { duration: 500 })
-    rotation.value = withTiming(360, { duration: 500 })
-    scale.value = withTiming(1, { duration: 500 }, () => {
-      bgOpacity.value = withTiming(0, { duration: 500 }, () => {
-        runOnJS(onAnimationComplete)()
-      })
+    opacity.value = withTiming(1, { duration: 1000 })
+    rotation.value = withTiming(360, { duration: 1000 })
+    scale.value = withTiming(1, { duration: 1000 }, () => {
+      runOnJS(setIsInitialAnimationDone)(true)
     })
   }
 
-  const onAnimationComplete = async () => {
-    setTimeout(() => setIsAppReady(true), 500)
+  const startFinalAnimation = () => {
+    bgOpacity.value = withTiming(0, { duration: 1000 }, () => {
+      runOnJS(onAnimationComplete)()
+    })
+  }
+
+  const onAnimationComplete = () => {
+    setTimeout(() => setIsAppReady(true), 1000)
   }
 
   const animatedStyles = useAnimatedStyle(() => {
@@ -52,9 +63,9 @@ export function SplashScreen({ children, loaded }: { children: React.ReactNode; 
   })
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={styles.wrapper}>
       {children}
-      {(!isAppReady || !loaded) && (
+      {!isAppReady && (
         <AnimatedView style={[styles.container, animatedBgStyles]}>
           <AnimatedImage
             source={require('../assets/RiseMainIcon.png')}
@@ -68,6 +79,9 @@ export function SplashScreen({ children, loaded }: { children: React.ReactNode; 
 }
 
 const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
   container: {
     ...StyleSheet.absoluteFillObject,
     alignItems: 'center',

--- a/apps/mobile/src/splash-screen.tsx
+++ b/apps/mobile/src/splash-screen.tsx
@@ -1,0 +1,71 @@
+import * as Splash from 'expo-splash-screen'
+import React, { useEffect, useState } from 'react'
+import { Image, StyleSheet, View } from 'react-native'
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
+
+Splash.preventAutoHideAsync()
+
+const AnimatedImage = Animated.createAnimatedComponent(Image)
+
+export function SplashScreen({ children, loaded }: { children: React.ReactNode; loaded: boolean }) {
+  const [isAppReady, setIsAppReady] = useState(false)
+  const opacity = useSharedValue(0)
+  const scale = useSharedValue(0.5)
+  const rotation = useSharedValue(0)
+
+  useEffect(() => {
+    startAnimation()
+  }, [])
+
+  const startAnimation = async () => {
+    await Splash.hideAsync()
+    opacity.value = withTiming(1, { duration: 2000 })
+    rotation.value = withTiming(360, { duration: 2000 })
+    scale.value = withTiming(1, { duration: 2000 }, () => {
+      runOnJS(onAnimationComplete)()
+    })
+  }
+
+  const onAnimationComplete = async () => {
+    setTimeout(() => setIsAppReady(true), 1000)
+  }
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+      transform: [{ scale: scale.value }, { rotate: rotation.value + 'deg' }],
+    }
+  })
+
+  if (!isAppReady || !loaded) {
+    return (
+      <View style={styles.container}>
+        <AnimatedImage
+          source={require('../assets/RiseMainIcon.png')}
+          style={[styles.logo, animatedStyles]}
+          resizeMode="contain"
+        />
+      </View>
+    )
+  }
+
+  return <>{children}</>
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#260162',
+  },
+  logo: {
+    width: 250,
+    height: 250,
+  },
+})

--- a/apps/mobile/src/splash-screen.tsx
+++ b/apps/mobile/src/splash-screen.tsx
@@ -42,12 +42,8 @@ export function SplashScreen({ children, loaded }: { children: React.ReactNode; 
 
   const startFinalAnimation = () => {
     bgOpacity.value = withTiming(0, { duration: 1000 }, () => {
-      runOnJS(onAnimationComplete)()
+      runOnJS(setIsAppReady)(true)
     })
-  }
-
-  const onAnimationComplete = () => {
-    setTimeout(() => setIsAppReady(true), 1000)
   }
 
   const animatedStyles = useAnimatedStyle(() => {


### PR DESCRIPTION
As a followup to #170 i took a while to create this PR, let me know what you think.

* Removed image splash screen (left only bg colour)
* Added custom `splashscreen` implementation in JS with some animations.

Let me know what do you think, ofc all of the values timings are up to discussion 😄 

## With spin
https://github.com/user-attachments/assets/d7378289-99b0-4e54-9dd7-108a75559dc0

## Without spin
https://github.com/user-attachments/assets/c10088ba-b01b-4c3e-9f3d-56d0974e4bdd

