### PR TITLE
feat: easier deployment of dev server to production

### DIFF
--- a/example/demo/src/index.ts
+++ b/example/demo/src/index.ts
@@ -13,7 +13,7 @@ const port = Number(process.env.PORT || '3005')
 const server = createWSServer(models, port)
 
 if (process.env.NODE_ENV === 'development') {
-  setupRiseTools({ server })
+  setupRiseTools({ server, projectKey: process.env.RISE_PROJECT_KEY })
 }
 
 import '@rise-tools/kit-react-navigation/server'

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -51,7 +51,7 @@ export function clearTerminal() {
   process.stdout.write('\x1Bc')
 }
 
-async function getProjectKey(): Promise<string> {
+export async function getProjectKey(): Promise<string> {
   const configDir = path.join(process.cwd(), '.rise')
   const configPath = path.join(configDir, 'projectKey')
 
@@ -65,9 +65,7 @@ async function getProjectKey(): Promise<string> {
   return await fs.readFile(configPath, { encoding: 'utf-8' })
 }
 
-export async function startTunnel(port: number) {
-  const projectKey = await getProjectKey()
-
+export async function startTunnel({ port, projectKey }: { port: number; projectKey: string }) {
   const session = spawn(
     'ssh',
     [

--- a/packages/cli/src/welcome.ts
+++ b/packages/cli/src/welcome.ts
@@ -8,6 +8,7 @@ import {
   getConnectionInfo,
   getConnectionURL,
   getHost,
+  getProjectKey,
   startTunnel,
 } from './utils'
 import { minimist } from './zx'
@@ -26,9 +27,11 @@ const opts = minimist<Options>(process.argv.slice(2), {
 export async function setupRiseTools({
   server,
   tunnel = opts.tunnel,
+  projectKey,
 }: {
   server: Server
   tunnel?: boolean
+  projectKey?: string
 }) {
   const host = (await getHost()) || 'localhost'
 
@@ -39,10 +42,16 @@ export async function setupRiseTools({
   console.log(logo())
   console.log(`Listening on ${highlight(localUrl)}`)
 
+  if (!projectKey) {
+    projectKey = await getProjectKey()
+  }
+
   let deepLinkUrl = localUrl
   if (tunnel) {
     try {
-      const host = await spinner('Starting the tunnel...', () => startTunnel(server.port))
+      const host = await spinner('Starting the tunnel...', async () =>
+        startTunnel({ port: server.port, projectKey })
+      )
       const tunnelUrl = `${server.protocol}://${host}`
       console.log(`Access anywhere on ${highlight(tunnelUrl)}`)
 


### PR DESCRIPTION
While our demo server is not really production ready (yet), nor its this pipeline intended to be production ready, we did deploy our demo server to Render with tunnel option, so that everyone can continue accessing our demo from the conference by the QR code.

Unfortunately, that means [I had to create a separate Github repository, commit `.rise` folder to it and deploy the entire project.](https://github.com/rise-tools/vibes-example-server/tree/main/.rise) Otherwise, `setupRiseTools` wouldn't know what projectKey to use.

This PR adds ability to pass it via argument, which can e.g. be an environmental variable. That way, we can setup deployments without leaking secrets.

Once merged and released, I will open source (make public) repository with "vibes" example that is currently private due to key being committed.

I figured this might be useful for some people in the future too!