### PR TITLE
fix: events not working for '' path 

### DIFF
--- a/packages/server/src/ws-connection.ts
+++ b/packages/server/src/ws-connection.ts
@@ -125,7 +125,6 @@ export function connectWebSocket(context: WSServerContext, ws: WebSocket) {
     const { path } = target
     try {
       const [storeName, ...lookupPath] = path
-      if (!storeName) throw new Error('Missing store name in event path')
       if (typeof storeName !== 'string') throw new Error('Store name must be a string')
       const model = getModel(storeName)
       if (!model) throw new Error(`Model not found for store name: ${storeName}`)


### PR DESCRIPTION
Javascript 😆 `if(!storeName)` will be true when `storeName` is an empty string, which makes events not run when within `''` model. 

Second check is enough. Anything that is not a string is invalid here, and `typeof` will handle both undefined/nulls just fine, in case they ever happen.

In fact, this check is necessary because we validate `event` with Zod and path will always be defined, otherwise it will throw an error elsewhere. 

