### PR TITLE
fix: query model should auto-load on subscribe

### DIFF
--- a/packages/server/src/__tests__/model-query.test.ts
+++ b/packages/server/src/__tests__/model-query.test.ts
@@ -69,4 +69,14 @@ describe('query model', () => {
     expect(loader).toBeCalledTimes(2)
     expect(subHandle).toBeCalledTimes(2)
   })
+  test('subscribe with auto-load', async () => {
+    const result = 1
+    const loader = vi.fn(() => Promise.resolve(result))
+    const q = query(loader)
+    const [subHandle, waitToHaveBeenCalled] = createWaitableMock()
+    q.subscribe(subHandle)
+    await waitToHaveBeenCalled(1)
+    expect(subHandle).toBeCalledTimes(1)
+    expect(subHandle).toBeCalledWith(1)
+  })
 })

--- a/packages/server/src/model-query.ts
+++ b/packages/server/src/model-query.ts
@@ -42,6 +42,10 @@ export function query<V>(loadInput: () => Promise<V>): QueryModel<V> {
     },
     subscribe: (listener) => {
       subscribers.add(listener)
+      if (!isValid) {
+        clearTimeout(updateSchedule)
+        updateSchedule = setTimeout(load, 1)
+      }
       if (state !== undefined) listener(state)
       return () => {
         subscribers.delete(listener)


### PR DESCRIPTION
I noticed the query model was not loading as expected when a client subscribes to it (or through a view)

This fixes the issue and includes a test to verify the behavior and prevent regressions