### PR TITLE
fix: streams: avoid extra re-subscription

### DIFF
--- a/packages/react/src/streams.ts
+++ b/packages/react/src/streams.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 
 import { JSONValue } from './rise'
 
@@ -36,9 +36,12 @@ export function createWritableStream<S extends JSONValue>(initState: S): Writabl
 
 export function useStream<T>(stream: Stream<T>): T {
   return useSyncExternalStore(
-    (onStoreChange) => {
-      return stream ? stream.subscribe(onStoreChange) : () => {}
-    },
+    useCallback(
+      (onStoreChange) => {
+        return stream ? stream.subscribe(onStoreChange) : () => {}
+      },
+      [stream]
+    ),
     () => stream.get()
   )
 }


### PR DESCRIPTION
This lack of memoization was causing aggressive re-subscription internally to rise