### PR TITLE
feat: allow all types of ReactNode JSX to be rendered on the server

### DIFF
--- a/packages/react/src/__tests__/jsx-runtime.test.tsx
+++ b/packages/react/src/__tests__/jsx-runtime.test.tsx
@@ -1,6 +1,6 @@
 /* @jsxImportSource .. */
 
-import type { ReactNode } from 'react'
+import type { PropsWithChildren, ReactNode } from 'react'
 import { expect, it, vi } from 'vitest'
 
 import { createComponentDefinition } from '../jsx-runtime'
@@ -141,6 +141,48 @@ it('should set static children', () => {
         "key": undefined,
         "props": {},
       },
+      "component": "View",
+      "key": undefined,
+      "props": {},
+    }
+  `)
+})
+
+it('should handle primitive values inside the server-side component', () => {
+  function Render({ children }: PropsWithChildren) {
+    return children
+  }
+  expect(
+    <View>
+      <Render>{null}</Render>
+      <Render>{undefined}</Render>
+      <Render>{1}</Render>
+      <Render>{'hello world'}</Render>
+      <Render>{true}</Render>
+      <Render>{[0, 1, 2]}</Render>
+      <Render>{new Set([0, 1, 2])}</Render>
+    </View>
+  ).toMatchInlineSnapshot(`
+    {
+      "$": "component",
+      "$staticChildren": true,
+      "children": [
+        null,
+        undefined,
+        1,
+        "hello world",
+        true,
+        [
+          0,
+          1,
+          2,
+        ],
+        Set {
+          0,
+          1,
+          2,
+        },
+      ],
       "component": "View",
       "key": undefined,
       "props": {},

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -1,11 +1,10 @@
-import type { JSXElementConstructor, ReactElement } from 'react'
+import type { JSXElementConstructor, ReactElement, ReactNode } from 'react'
 import React from 'react'
 
 import { event } from './events'
 import {
   ComponentModelState,
   HandlerFunction,
-  isComponentModelState,
   ReferencedModelState,
   ServerEventModelState,
   ServerHandlerModelState,
@@ -13,11 +12,12 @@ import {
 } from './rise'
 
 type ServerComponent = ComponentModelState<ServerEventModelState>
+
 type JSXFactory = (
-  componentFactory: ((props: any) => ServerComponent | ReactElement) | undefined,
+  componentFactory: ((props: any) => ServerComponent | ReactNode) | undefined,
   { children, ...passedProps }: Record<string, any>,
   key?: string
-) => ServerComponent | null
+) => ServerComponent | Exclude<ReactNode, ReactElement>
 
 export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
   Object.defineProperty(passedProps.children, '$static', {
@@ -36,10 +36,9 @@ export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
     }
   }
   const el = componentFactory(passedProps)
-  if (isComponentModelState(el)) {
+  if (!isReactElement(el)) {
     return el
   }
-  if (el === null) return null
   if (typeof el.type !== 'string') {
     throw new Error('Invalid component. Make sure to use server-side version of your components.')
   }

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -11,13 +11,40 @@ import {
   StateModelState,
 } from './rise'
 
-type ServerComponent = ComponentModelState<ServerEventModelState>
+type RiseElement = ComponentModelState<ServerEventModelState>
 
 type JSXFactory = (
-  componentFactory: ((props: any) => ServerComponent | ReactNode) | undefined,
+  /**
+   * When rendering fragments, `componentFactory` will be undefined
+   * ```tsx
+   * <>
+   *   <View>foo</View>
+   * </>
+   * ```
+   *
+   * When rendering server-side component definitions, `componentFactory` will return `RiseElement`
+   * ```tsx
+   * const View = createComponentDefinition('View')
+   *
+   * <View />
+   * ```
+   *
+   * When rendering function defined on the server, `componentFactory` will return `ReactNode` or `RiseElement`,
+   * depending whether it returns a primitive value or a component definition:
+   * ```tsx
+   * const View = createComponentDefinition('View')
+   *
+   * function Helper() {
+   *   return isMobile ? <View /> : 'foo'
+   * }
+   *
+   * <Helper />
+   * ```
+   */
+  componentFactory: ((props: any) => ReactNode | RiseElement) | undefined,
   { children, ...passedProps }: Record<string, any>,
   key?: string
-) => ServerComponent | Exclude<ReactNode, ReactElement>
+) => Exclude<ReactNode, ReactElement> | RiseElement
 
 export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
   Object.defineProperty(passedProps.children, '$static', {

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -17,7 +17,7 @@ type JSXFactory = (
   componentFactory: ((props: any) => ServerComponent | ReactElement) | undefined,
   { children, ...passedProps }: Record<string, any>,
   key?: string
-) => ServerComponent
+) => ServerComponent | null
 
 export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
   Object.defineProperty(passedProps.children, '$static', {
@@ -39,6 +39,7 @@ export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
   if (isComponentModelState(el)) {
     return el
   }
+  if (el === null) return null
   if (typeof el.type !== 'string') {
     throw new Error('Invalid component. Make sure to use server-side version of your components.')
   }


### PR DESCRIPTION
You can now return more than just component definitions from within your server side helpers.