### PR TITLE
feat: improves DraggableFlatList

### DIFF
--- a/packages/kit/src/client/DraggableFlatList.tsx
+++ b/packages/kit/src/client/DraggableFlatList.tsx
@@ -3,9 +3,9 @@ import DraggableFlatList, {
   DraggableFlatListProps,
   ScaleDecorator,
 } from 'react-native-draggable-flatlist'
-import { TouchableOpacity } from 'react-native-gesture-handler'
+import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 
-type Item = { key: string; label: React.ReactElement }
+type Item = { key: string; label: React.ReactElement; onPress?: () => void }
 
 export function RNDraggableFlatList(
   props: Omit<
@@ -14,6 +14,7 @@ export function RNDraggableFlatList(
   > & {
     header?: React.ReactElement
     footer?: React.ReactElement
+    onItemPress?: (key: Item['key']) => void
     onReorder?: (data: Item['key'][]) => void
   }
 ) {
@@ -36,9 +37,16 @@ export function RNDraggableFlatList(
         const Item = () => item.label
         return (
           <ScaleDecorator>
-            <TouchableOpacity onLongPress={drag} disabled={isActive}>
+            <TouchableWithoutFeedback
+              onLongPress={drag}
+              disabled={isActive}
+              onPress={() => {
+                item.onPress?.()
+                props.onItemPress?.(item.key)
+              }}
+            >
               <Item />
-            </TouchableOpacity>
+            </TouchableWithoutFeedback>
           </ScaleDecorator>
         )
       }}


### PR DESCRIPTION
- Use TouchableWithoutFeedback to mitigate the issue where the pressed state is stuck
- onPress callback for each item
- onPress callback for the whole component

Note: The issue is still present where the pressed state gets stuck down after dragging an item. This is a bug because the user needs to press it twice for the onPress callback to fire. But at least the user is not left with a bad visual state. Obviously we want a real fix for this, and when we have one, we can switch back to TouchableOpacity