### PR TITLE
feat: allow rendering iterable elements on the client

### DIFF
--- a/packages/react/src/__tests__/rise.test.tsx
+++ b/packages/react/src/__tests__/rise.test.tsx
@@ -69,6 +69,39 @@ it('should render an array of components', () => {
   `)
 })
 
+it('should render any iterable of components', () => {
+  const component = render(
+    <BaseRise
+      components={BUILT_IN_COMPONENTS}
+      model={
+        new Set([
+          'hello',
+          {
+            $: 'component',
+            component: 'View',
+            children: 'world',
+            props: {
+              height: new Set([1, 2, 3]),
+            },
+          },
+        ])
+      }
+      onEvent={vi.fn()}
+    />
+  )
+
+  expect(component.asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      hello
+      <div
+        height="1,2,3"
+      >
+        world
+      </div>
+    </DocumentFragment>
+  `)
+})
+
 it('should use component key when provided', () => {
   const component = render(
     <BaseRise

--- a/packages/react/src/rise.tsx
+++ b/packages/react/src/rise.tsx
@@ -261,7 +261,7 @@ export function BaseRise({
     getLocalStateValue: (state: StateModelState) => JSONValue,
     path: Path
   ): any {
-    if (!propValue || typeof propValue !== 'object') {
+    if (propValue === null || typeof propValue !== 'object') {
       return propValue
     }
     if (


### PR DESCRIPTION
Following up to previous PR, this adds ability to render Iterables, not just Arrays, as children and props. While our transportation mechanism currently does not support transporting anything but arrays, this makes it aligned with what server outputs, in case it gets passed directly as a prop.

Previously, this would throw an error that objects can't be rendered, which is correct, just not for iterables!