### PR TITLE
fix: rendering Rise JSX from React Native / Metro context

### DIFF
--- a/packages/react/src/events.native.ts
+++ b/packages/react/src/events.native.ts
@@ -1,4 +1,0 @@
-// tbd: move events.ts to a separate package so React Native can build
-// without failing on Node dependency
-//
-// Easiest until experimental_packageExports is turned on by default


### PR DESCRIPTION
Historically, we had this empty file so React Native can build (events had some references to node:crypto).

Now, it's not needed. We're actually rendering some Rise JSX inside React Native application (for fallback UI) and this is breaking it.