### PR TITLE
fix: warning about missing keys when using server-side helpers

### DIFF
--- a/packages/react/src/__tests__/jsx-runtime.test.tsx
+++ b/packages/react/src/__tests__/jsx-runtime.test.tsx
@@ -190,3 +190,73 @@ it('should handle primitive values inside the server-side component', () => {
     }
   `)
 })
+
+it('should assign key to a component definition returned by a server-side helper', () => {
+  function Button() {
+    return <View />
+  }
+  expect(
+    <View>
+      {['foo', 'bar'].map((item) => (
+        <Button key={item} />
+      ))}
+    </View>
+  ).toMatchInlineSnapshot(`
+    {
+      "$": "component",
+      "children": [
+        {
+          "$": "component",
+          "children": undefined,
+          "component": "View",
+          "key": "foo",
+          "props": {},
+        },
+        {
+          "$": "component",
+          "children": undefined,
+          "component": "View",
+          "key": "bar",
+          "props": {},
+        },
+      ],
+      "component": "View",
+      "key": undefined,
+      "props": {},
+    }
+  `)
+})
+
+it('should wrap primitive values with a fragment to assign a key', () => {
+  function Text() {
+    return 'Hello World'
+  }
+  expect(
+    <View>
+      {['foo', 'bar'].map((item) => (
+        <Text key={item} />
+      ))}
+    </View>
+  ).toMatchInlineSnapshot(`
+    {
+      "$": "component",
+      "children": [
+        {
+          "$": "component",
+          "children": "Hello World",
+          "component": "rise-tools/react/Fragment",
+          "key": "foo",
+        },
+        {
+          "$": "component",
+          "children": "Hello World",
+          "component": "rise-tools/react/Fragment",
+          "key": "bar",
+        },
+      ],
+      "component": "View",
+      "key": undefined,
+      "props": {},
+    }
+  `)
+})

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -5,6 +5,7 @@ import { event, ServerEventModelState } from './events'
 import {
   ComponentModelState,
   HandlerFunction,
+  isComponentModelState,
   ReferencedModelState,
   ServerHandlerModelState,
   StateModelState,
@@ -63,7 +64,19 @@ export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
   }
   const el = componentFactory(passedProps)
   if (!isReactElement(el)) {
-    return el
+    if (!isComponentModelState(el)) {
+      return {
+        $: 'component',
+        component: 'rise-tools/react/Fragment',
+        key,
+        props: {},
+        children: el,
+      }
+    }
+    return {
+      ...el,
+      key,
+    }
   }
   if (typeof el.type !== 'string') {
     throw new Error('Invalid component. Make sure to use server-side version of your components.')

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -22,15 +22,17 @@ type JSXFactory = (
    * </>
    * ```
    *
-   * When rendering server-side component definitions, `componentFactory` will return `RiseElement`
+   * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
    * ```tsx
    * const View = createComponentDefinition('View')
    *
    * <View />
    * ```
    *
+   * See `createComponentDefinition` function for more details.
+   *
    * When rendering function defined on the server, `componentFactory` will return `ReactNode` or `RiseElement`,
-   * depending whether it returns a primitive value or a component definition:
+   * depending whether it returns a primitive value or a server-side component definition:
    * ```tsx
    * const View = createComponentDefinition('View')
    *
@@ -64,19 +66,22 @@ export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
   }
   const el = componentFactory(passedProps)
   if (!isReactElement(el)) {
-    if (!isComponentModelState(el)) {
+    if (!key) {
+      return el
+    }
+    if (isComponentModelState(el)) {
       return {
-        $: 'component',
-        component: 'rise-tools/react/Fragment',
+        ...el,
         key,
-        props: {},
-        children: el,
       }
     }
+    // tbd: fix type casting
     return {
-      ...el,
+      $: 'component',
+      component: 'rise-tools/react/Fragment',
       key,
-    }
+      children: el,
+    } as RiseElement
   }
   if (typeof el.type !== 'string') {
     throw new Error('Invalid component. Make sure to use server-side version of your components.')

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -1,17 +1,15 @@
-import type { JSXElementConstructor, ReactElement, ReactNode } from 'react'
+import type { JSXElementConstructor, ReactElement } from 'react'
 import React from 'react'
 
-import { event, ServerEventModelState } from './events'
+import { event } from './events'
 import {
-  ComponentModelState,
   HandlerFunction,
   isComponentModelState,
   ReferencedModelState,
   ServerHandlerModelState,
+  ServerModelState,
   StateModelState,
 } from './rise'
-
-type RiseElement = ComponentModelState<ServerEventModelState>
 
 type JSXFactory = (
   /**
@@ -28,11 +26,9 @@ type JSXFactory = (
    *
    * <View />
    * ```
-   *
    * See `createComponentDefinition` function for more details.
    *
-   * When rendering function defined on the server, `componentFactory` will return `ReactNode` or `RiseElement`,
-   * depending whether it returns a primitive value or a server-side component definition:
+   * When rendering function defined on the server, `componentFactory` will return `ServerModelState`:
    * ```tsx
    * const View = createComponentDefinition('View')
    *
@@ -43,10 +39,10 @@ type JSXFactory = (
    * <Helper />
    * ```
    */
-  componentFactory: ((props: any) => ReactNode | RiseElement) | undefined,
+  componentFactory: ((props: any) => ServerModelState | ReactElement) | undefined,
   { children, ...passedProps }: Record<string, any>,
   key?: string
-) => Exclude<ReactNode, ReactElement> | RiseElement
+) => ServerModelState
 
 export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
   Object.defineProperty(passedProps.children, '$static', {
@@ -75,13 +71,12 @@ export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
         key,
       }
     }
-    // tbd: fix type casting
     return {
       $: 'component',
       component: 'rise-tools/react/Fragment',
       key,
       children: el,
-    } as RiseElement
+    }
   }
   if (typeof el.type !== 'string') {
     throw new Error('Invalid component. Make sure to use server-side version of your components.')

--- a/templates/full/src/inventory/ui.tsx
+++ b/templates/full/src/inventory/ui.tsx
@@ -38,6 +38,7 @@ function HomeScreen({ inventory }: { inventory?: Inventory }) {
       <ScrollView contentContainerStyle={{ paddingBottom: 20 }}>
         {inventory?.map((item, idx) => (
           <Button
+            key={item.key}
             unstyled
             onPress={navigate(`inventoryItem/${item.key}`, { title: item.title })}
             pressStyle={{ opacity: 0.8 }}

--- a/templates/full/src/vibes/ui.tsx
+++ b/templates/full/src/vibes/ui.tsx
@@ -91,7 +91,7 @@ export function VibeResults({ vibes }: { vibes?: VibesState }) {
           const vibeCount = vibes?.[vibe.icon] || 0
 
           return (
-            <XStack padding="$2" alignItems="center" justifyContent="space-between">
+            <XStack key={vibe.icon} padding="$2" alignItems="center" justifyContent="space-between">
               <View flex={vibeCount} margin="$2">
                 <View padding="$2" backgroundColor={`$${vibe.theme}8`} borderRadius="$4">
                   <SizableText size="$9">{vibe.icon}</SizableText>


### PR DESCRIPTION
Aside from fixing the warning itself, I tried to simplify and make the naming inside JSX less confusing. This file is evolving (as JSX support is still experimental) and I felt like certain things did not make much sense anymore!

Mainly:
- Fixed wrong comment (a bit misleading) as far as what is the return type of `componentFactory`
- Removed `RiseElement` and `ReactNode` types in favour of `ServerModelState`. That allowed to remove type casting and other workarounds that were present in this PR in earlier commits