### PR TITLE
refactor: remove dead Fragment code

### DIFF
--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -2,3 +2,5 @@ import { jsx, jsxs } from './jsx-runtime'
 
 export const jsxDEV = jsx
 export const jsxsDEV = jsxs
+
+export { Fragment } from './jsx-runtime'

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -13,13 +13,6 @@ import {
 
 type JSXFactory = (
   /**
-   * When rendering fragments, `componentFactory` will be undefined
-   * ```tsx
-   * <>
-   *   <View>foo</View>
-   * </>
-   * ```
-   *
    * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
    * ```tsx
    * const View = createComponentDefinition('View')
@@ -39,7 +32,7 @@ type JSXFactory = (
    * <Helper />
    * ```
    */
-  componentFactory: ((props: any) => ServerModelState | ReactElement) | undefined,
+  componentFactory: (props: any) => ServerModelState | ReactElement,
   { children, ...passedProps }: Record<string, any>,
   key?: string
 ) => ServerModelState
@@ -53,13 +46,6 @@ export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
 }
 
 export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
-  if (typeof componentFactory === 'undefined') {
-    return {
-      $: 'component',
-      component: 'rise-tools/react/Fragment',
-      children: passedProps.children,
-    }
-  }
   const el = componentFactory(passedProps)
   if (!isReactElement(el)) {
     if (!key) {


### PR DESCRIPTION
JSX 
```
const View = (
  <>
    <div />
  </>
)
```
is transformed to this
```
import { jsx as _jsx, Fragment as _Fragment } from "react/jsx-runtime";
const View = /*#__PURE__*/_jsx(_Fragment, {
  children: /*#__PURE__*/_jsx("div", {})
});
```
As you can see, `Fragment` from `jsx-runtime` is used as `componentFactory`, just like any other component. Beforehand, we didn't have it, so it was undefined. 

We actually already export it from `jsx-runtime`, so I just added it to `jsx-dev-runtime` too to make it work and that `if` is no longer needed. 