### PR TITLE
fix: proper handling of static children in dev runtime

### DIFF
--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -1,5 +1,5 @@
-import { jsx } from './jsx-runtime'
+import { jsxImpl } from './jsx-runtime'
 
-export const jsxDEV = jsx
+export const jsxDEV = jsxImpl
 
 export { Fragment } from './jsx-runtime'

--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -2,3 +2,5 @@ import { jsx, jsxs } from './jsx-runtime'
 
 export const jsxDEV = jsx
 export const jsxsDEV = jsxs
+
+export { Fragment } from './jsx-runtime'

--- a/packages/react/src/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx-dev-runtime.ts
@@ -1,6 +1,5 @@
-import { jsx, jsxs } from './jsx-runtime'
+import { jsx } from './jsx-runtime'
 
 export const jsxDEV = jsx
-export const jsxsDEV = jsxs
 
 export { Fragment } from './jsx-runtime'

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -13,13 +13,6 @@ import {
 
 type JSXFactory = (
   /**
-   * When rendering fragments, `componentFactory` will be undefined
-   * ```tsx
-   * <>
-   *   <View>foo</View>
-   * </>
-   * ```
-   *
    * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
    * ```tsx
    * const View = createComponentDefinition('View')
@@ -39,7 +32,7 @@ type JSXFactory = (
    * <Helper />
    * ```
    */
-  componentFactory: ((props: any) => ServerModelState | ReactElement) | undefined,
+  componentFactory: (props: any) => ServerModelState | ReactElement,
   { children, ...passedProps }: Record<string, any>,
   key?: string
 ) => ServerModelState
@@ -53,13 +46,6 @@ export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
 }
 
 export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
-  if (typeof componentFactory === 'undefined') {
-    return {
-      $: 'component',
-      component: 'rise-tools/react/Fragment',
-      children: passedProps.children,
-    }
-  }
   const el = componentFactory(passedProps)
   if (!isReactElement(el)) {
     if (!key) {

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -11,7 +11,7 @@ import {
   StateModelState,
 } from './rise'
 
-type JSXFactory = (
+export type JSXFactory = (
   /**
    * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
    * ```tsx
@@ -34,18 +34,21 @@ type JSXFactory = (
    */
   componentFactory: (props: any) => ServerModelState | ReactElement,
   { children, ...passedProps }: Record<string, any>,
-  key?: string
+  key?: string,
+  isStaticChildren?: boolean
 ) => ServerModelState
 
 export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
-  Object.defineProperty(passedProps.children, '$static', {
-    value: true,
-    enumerable: false,
-  })
-  return jsx(componentFactory, passedProps, key)
+  return jsx(componentFactory, passedProps, key, true)
 }
 
-export const jsx: JSXFactory = (componentFactory, passedProps, key) => {
+export const jsx: JSXFactory = (componentFactory, passedProps, key, isStaticChildren) => {
+  if (isStaticChildren) {
+    Object.defineProperty(passedProps.children, '$static', {
+      value: true,
+      enumerable: false,
+    })
+  }
   const el = componentFactory(passedProps)
   if (!isReactElement(el)) {
     if (!key) {

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -11,7 +11,7 @@ import {
   StateModelState,
 } from './rise'
 
-export type JSXFactory = (
+type JSXFactory = (
   /**
    * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
    * ```tsx

--- a/packages/react/src/jsx-runtime.tsx
+++ b/packages/react/src/jsx-runtime.tsx
@@ -11,38 +11,43 @@ import {
   StateModelState,
 } from './rise'
 
-type JSXFactory = (
-  /**
-   * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
-   * ```tsx
-   * const View = createComponentDefinition('View')
-   *
-   * <View />
-   * ```
-   * See `createComponentDefinition` function for more details.
-   *
-   * When rendering function defined on the server, `componentFactory` will return `ServerModelState`:
-   * ```tsx
-   * const View = createComponentDefinition('View')
-   *
-   * function Helper() {
-   *   return isMobile ? <View /> : 'foo'
-   * }
-   *
-   * <Helper />
-   * ```
-   */
-  componentFactory: (props: any) => ServerModelState | ReactElement,
-  { children, ...passedProps }: Record<string, any>,
-  key?: string,
-  isStaticChildren?: boolean
-) => ServerModelState
+/**
+ * When rendering server-side component definitions, `componentFactory` will return `ReactElement`:
+ * ```tsx
+ * const View = createComponentDefinition('View')
+ *
+ * <View />
+ * ```
+ * See `createComponentDefinition` function for more details.
+ *
+ * When rendering function defined on the server, `componentFactory` will return `ServerModelState`:
+ * ```tsx
+ * const View = createComponentDefinition('View')
+ *
+ * function Helper() {
+ *   return isMobile ? <View /> : 'foo'
+ * }
+ *
+ * <Helper />
+ * ```
+ */
+type ComponentFactory = (props: any) => ServerModelState | ReactElement
+type Props = Record<string, any>
 
-export const jsxs: JSXFactory = (componentFactory, passedProps, key) => {
-  return jsx(componentFactory, passedProps, key, true)
+export const jsxs = (componentFactory: ComponentFactory, props: Props, key: string) => {
+  return jsxImpl(componentFactory, props, key, true)
 }
 
-export const jsx: JSXFactory = (componentFactory, passedProps, key, isStaticChildren) => {
+export const jsx = (componentFactory: ComponentFactory, props: Props, key: string) => {
+  return jsxImpl(componentFactory, props, key, false)
+}
+
+export const jsxImpl = (
+  componentFactory: ComponentFactory,
+  passedProps: Props,
+  key: string,
+  isStaticChildren: boolean
+) => {
   if (isStaticChildren) {
     Object.defineProperty(passedProps.children, '$static', {
       value: true,


### PR DESCRIPTION
jsxDEV has different signature, there's no `jsxsDEV`, it takes `isStatic` as an additional boolean argument. We can't just export two factories, one for dynamic, second for static, we have to handle it differently, hence the change.

FWIW the handling is very similar to how React does this internally now! 

https://github.com/facebook/react/blob/main/packages/react/src/jsx/ReactJSXElement.js#L490-L501

(note explicit boolean)

```tsx
const profile = (
  <div>
    <img src="avatar.png" className="profile" />
    <h3>{[user.firstName, user.lastName].join(" ")}</h3>
  </div>
);
```

```tsx
import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";

const _jsxFileName = "input.jsx";
const profile = _jsxDEV("div", {
  children: [
    _jsxDEV("img", {
      src: "avatar.png",
      className: "profile",
    }, undefined, false, { fileName: _jsxFileName, lineNumber: 3, columnNumber: 5 }, this),
    _jsxDEV("h3", {
      children: [user.firstName, user.lastName].join(" "),
    }, undefined, false, { fileName: _jsxFileName, lineNumber: 4, columnNumber: 5 }, this),
  ]},
  undefined, false, { fileName: _jsxFileName, lineNumber: 2, columnNumber: 3 }, this
);
```