### PR TITLE
fix: state mutation setter allows silent updates

### DIFF
--- a/packages/server/src/__tests__/model-state.test.ts
+++ b/packages/server/src/__tests__/model-state.test.ts
@@ -15,6 +15,26 @@ describe('model-state', () => {
     setS((s) => s + 1)
     expect(s.get()).toBe(1)
   })
+  test('mutation setter with no update', () => {
+    const handler = vi.fn()
+    const [s, setS] = state(0)
+    const release = s.subscribe(handler)
+    expect(handler).toBeCalledTimes(1)
+    expect(handler).toHaveBeenLastCalledWith(0)
+    expect(s.get()).toBe(0)
+    setS((s) => s)
+    expect(handler).toBeCalledTimes(1)
+    setS((s) => s + 1)
+    expect(handler).toBeCalledTimes(2)
+    expect(handler).toHaveBeenLastCalledWith(1)
+    release()
+    setS((s) => s + 1)
+    expect(s.get()).toBe(2)
+    // this is the main thing we are checking in this test:
+    expect(handler).toBeCalledTimes(2)
+    // if the mutation setter is returns the input value, the subscriber should not be called
+    expect(handler).toHaveBeenLastCalledWith(1)
+  })
   test('subscribe', () => {
     const handler = vi.fn()
     const [s, setS] = state(0)

--- a/packages/server/src/model-state.ts
+++ b/packages/server/src/model-state.ts
@@ -7,11 +7,13 @@ export function state<T>(initial: T): [StateModel<T>, StateSetter<T>] {
     return value
   }
   function set(updater: T | ((state: T) => T)) {
+    const lastValue = value
     if (typeof updater === 'function') {
       value = (updater as (state: T) => T)(value)
     } else {
       value = updater
     }
+    if (lastValue === value) return
     listeners.forEach((listener) => listener(value))
   }
   function subscribe(listener: (newState: T) => void) {


### PR DESCRIPTION
One of the main purposes of the state setter function is to allow the mutation to return null without emitting an update to subscribers

Previously the subscribers would always be called, this makes it so you can silently call setState with the same value