### PR TITLE
fix: DraggableFlatList remounting header/footer

### DIFF
--- a/packages/kit/src/client/DraggableFlatList.tsx
+++ b/packages/kit/src/client/DraggableFlatList.tsx
@@ -27,8 +27,8 @@ export function RNDraggableFlatList(
       {...props}
       data={data}
       keyExtractor={(item) => item.key}
-      ListHeaderComponent={props.header ? () => props.header : undefined}
-      ListFooterComponent={props.footer ? () => props.footer : undefined}
+      ListHeaderComponent={props.header}
+      ListFooterComponent={props.footer}
       onDragEnd={(e) => {
         setData(e.data)
         props.onReorder?.(e.data.map((item) => item.key))


### PR DESCRIPTION
Function is not necessary. Those accept React Element out of the box. If the issue persist, we may look into this inside Rise renderer.