### PR TITLE
feat: deprecate `header` and `footer` on DraggableFlatList

### DIFF
--- a/packages/kit/src/client/DraggableFlatList.tsx
+++ b/packages/kit/src/client/DraggableFlatList.tsx
@@ -8,10 +8,7 @@ import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 type Item = { key: string; label: React.ReactElement; onPress?: () => void }
 
 export function RNDraggableFlatList(
-  props: Omit<
-    DraggableFlatListProps<Item>,
-    'ListHeaderComponent' | 'ListFooterComponent' | 'keyExtractor' | 'renderItem' | 'onDragEnd'
-  > & {
+  props: Omit<DraggableFlatListProps<Item>, 'keyExtractor' | 'renderItem' | 'onDragEnd'> & {
     header?: React.ReactElement
     footer?: React.ReactElement
     onItemPress?: (key: Item['key']) => void
@@ -22,13 +19,19 @@ export function RNDraggableFlatList(
   useEffect(() => {
     setData(props.data)
   }, [props.data])
+  if (props.header) {
+    console.warn('DraggableFlatList: header is deprecated, use ListHeaderComponent instead')
+  }
+  if (props.footer) {
+    console.warn('DraggableFlatList: footer is deprecated, use ListHeaderComponent instead')
+  }
   return (
     <DraggableFlatList
       {...props}
+      ListHeaderComponent={props.header || props.ListHeaderComponent}
+      ListFooterComponent={props.footer || props.ListFooterComponent}
       data={data}
       keyExtractor={(item) => item.key}
-      ListHeaderComponent={props.header}
-      ListFooterComponent={props.footer}
       onDragEnd={(e) => {
         setData(e.data)
         props.onReorder?.(e.data.map((item) => item.key))

--- a/packages/kit/src/client/DraggableFlatList.tsx
+++ b/packages/kit/src/client/DraggableFlatList.tsx
@@ -27,8 +27,8 @@ export function RNDraggableFlatList(
       {...props}
       data={data}
       keyExtractor={(item) => item.key}
-      ListHeaderComponent={props.header ? () => props.header : undefined}
-      ListFooterComponent={props.footer ? () => props.footer : undefined}
+      ListHeaderComponent={props.header}
+      ListFooterComponent={props.footer}
       onDragEnd={(e) => {
         setData(e.data)
         props.onReorder?.(e.data.map((item) => item.key))

--- a/templates/full/src/controls/ui.tsx
+++ b/templates/full/src/controls/ui.tsx
@@ -373,8 +373,8 @@ function DraggableListExample() {
       <YStack flex={1} padding="$4">
         <DraggableFlatList
           data={data}
-          header={<H4>Best JavaScript frameworks</H4>}
-          footer={
+          ListHeaderComponent={<H4>Best JavaScript frameworks</H4>}
+          ListFooterComponent={
             <Text paddingVertical="$2">PS. You can reorder them to match your preferences!</Text>
           }
           onReorder={(keys) => {


### PR DESCRIPTION
Things brings it to feature parity with FlatList and other lists as well as DraggableFlatList itself. Deprecations will be removed in the upcoming releases, so please migrate if you're relying on this!